### PR TITLE
#38 [Extension] Gérer les erreurs d'appels à l'API de sauvegarde sur le backend

### DIFF
--- a/browser-extension/src/components/ui/tooltip.tsx
+++ b/browser-extension/src/components/ui/tooltip.tsx
@@ -1,0 +1,64 @@
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delay = 0,
+  ...props
+}: TooltipPrimitive.Provider.Props) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delay={delay}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+}
+
+function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  side = "top",
+  sideOffset = 4,
+  align = "center",
+  alignOffset = 0,
+  children,
+  ...props
+}: TooltipPrimitive.Popup.Props &
+  Pick<
+    TooltipPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <TooltipPrimitive.Popup
+          data-slot="tooltip-content"
+          className={cn(
+            "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 rounded-md px-3 py-1.5 text-xs data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 bg-foreground text-background z-50 w-fit max-w-xs origin-(--transform-origin)",
+            className
+          )}
+          {...props}
+        >
+          {children}
+          <TooltipPrimitive.Arrow className="size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 bg-foreground fill-foreground z-50 data-[side=bottom]:top-1 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+        </TooltipPrimitive.Popup>
+      </TooltipPrimitive.Positioner>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/browser-extension/src/components/ui/tooltip.tsx
+++ b/browser-extension/src/components/ui/tooltip.tsx
@@ -1,6 +1,6 @@
-import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function TooltipProvider({
   delay = 0,
@@ -12,15 +12,15 @@ function TooltipProvider({
       delay={delay}
       {...props}
     />
-  )
+  );
 }
 
 function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
 function TooltipContent({
@@ -49,7 +49,7 @@ function TooltipContent({
           data-slot="tooltip-content"
           className={cn(
             "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 rounded-md px-3 py-1.5 text-xs data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 bg-foreground text-background z-50 w-fit max-w-xs origin-(--transform-origin)",
-            className
+            className,
           )}
           {...props}
         >
@@ -58,7 +58,7 @@ function TooltipContent({
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>
-  )
+  );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/browser-extension/src/entrypoints/background/scraping/scrap-active-tab-message.ts
+++ b/browser-extension/src/entrypoints/background/scraping/scrap-active-tab-message.ts
@@ -1,9 +1,19 @@
+import { Post } from "@/shared/model/post";
+
 /**
  * Message sent to background to start scraping the active tab
  */
 export type ScrapActiveTabMessage = {
   msgType: "scrap-active-tab";
 };
+
+/**
+ * Message sent to background to reprocess a post with the backend.
+ */
+export interface ReprocessPostMessage {
+  msgType: "reprocess-post";
+  post: Post;
+}
 
 export function isScrapActiveTabMessage(
   message: unknown,
@@ -13,5 +23,16 @@ export function isScrapActiveTabMessage(
     message !== null &&
     "msgType" in message &&
     message.msgType === "scrap-active-tab"
+  );
+}
+
+export function isReprocessPostMessage(
+  message: unknown,
+): message is ReprocessPostMessage {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "msgType" in message &&
+    message.msgType === "reprocess-post"
   );
 }

--- a/browser-extension/src/entrypoints/posts/PostDetailPage.tsx
+++ b/browser-extension/src/entrypoints/posts/PostDetailPage.tsx
@@ -43,6 +43,9 @@ function PostDetailPage() {
               <div>
                 Capture: {new Date(post.scrapedAt).toLocaleDateString()}
               </div>
+              <div>
+                BackendId: {post.backendId}
+              </div>
             </div>
             <div className="italic">
               <p className="whitespace-pre-wrap">{post.textContent}</p>

--- a/browser-extension/src/entrypoints/posts/PostDetailPage.tsx
+++ b/browser-extension/src/entrypoints/posts/PostDetailPage.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from "react";
 import { getPostByIdAndScrapedAt } from "@/shared/storage/posts-storage";
 import { Post } from "@/shared/model/post";
-import { useParams } from "react-router";
+import { Link, useParams } from "react-router";
 import { CommentTreeTable } from "./CommentTreeTable";
+import { Check, MoveLeft, RefreshCcw, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 function PostDetailPage() {
   const { postId, scrapedAt } = useParams();
@@ -14,6 +16,17 @@ function PostDetailPage() {
       });
     }
   }, [postId, scrapedAt]);
+
+  const handleReprocess = async () => {
+    if (post) {
+      const result = await browser.runtime.sendMessage({
+        msgType: "reprocess-post",
+        post: post,
+      });
+      console.debug("PostDetailPage - Reprocess post message response", result);
+      globalThis.location.reload();
+    }
+  };
 
   return (
     <>
@@ -30,6 +43,17 @@ function PostDetailPage() {
               {post.author.name}
             </a>
           </h1>
+          <div className="text-left">
+            <Button
+              variant="link"
+              render={
+                <Link to="/">
+                  <MoveLeft /> Retour à la liste des publications
+                </Link>
+              }
+            />
+          </div>
+
           <h2 className="text-left pt-2 mb-4">Details</h2>
           <div className="rounded-md border text-left p-4 grid grid-cols-2">
             <div>
@@ -43,16 +67,29 @@ function PostDetailPage() {
               <div>
                 Capture: {new Date(post.scrapedAt).toLocaleDateString()}
               </div>
-              <div>
-                BackendId: {post.backendId}
-              </div>
             </div>
             <div className="italic">
               <p className="whitespace-pre-wrap">{post.textContent}</p>
             </div>
           </div>
 
-          <h2 className="text-left pt-2 mb-4">Commentaires</h2>
+          <h2 className="text-left pt-2 mb-4">Etat du traitement</h2>
+          <div className="text-left flex flex-row items-center gap-2  ">
+            {post.backendId && <Check className="text-green-500" />}
+            {!post.backendId && <X className="text-red-500" />}
+            <span className="font-medium">
+              {post.backendId && "Traitement effectué avec succès"}
+              {!post.backendId && "Echec du traitement"}
+            </span>
+            {!post.backendId && (
+              <Button className="ml-3" onClick={handleReprocess}>
+                <RefreshCcw className="mr-2" />
+                Relancer le traitement
+              </Button>
+            )}
+          </div>
+
+          <h2 className="text-left pt-2 my-4">Commentaires</h2>
 
           <CommentTreeTable comments={post.comments} />
         </>

--- a/browser-extension/src/entrypoints/posts/PostListPage.tsx
+++ b/browser-extension/src/entrypoints/posts/PostListPage.tsx
@@ -11,7 +11,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Spinner } from "@/components/ui/spinner";
-import { Check, CircleCheck, X } from "lucide-react";
+import { Check, X } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -76,7 +76,6 @@ function PostListPage() {
                     </TooltipContent>
                   </Tooltip>
                 </TableCell>
-                <TableCell> {post.scrapedAt}</TableCell>
                 <TableCell> {post.scrapedAt}</TableCell>
                 <TableCell> {post.socialNetwork}</TableCell>
                 <TableCell> {post.author.name}</TableCell>

--- a/browser-extension/src/entrypoints/posts/PostListPage.tsx
+++ b/browser-extension/src/entrypoints/posts/PostListPage.tsx
@@ -11,6 +11,12 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Spinner } from "@/components/ui/spinner";
+import { Check, CircleCheck, X } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 function downloadPost(post: Post) {
   console.log("Downloading first comment");
@@ -41,6 +47,7 @@ function PostListPage() {
         <Table>
           <TableHeader>
             <TableRow>
+              <TableHead>Traitement</TableHead>
               <TableHead>Date scraping</TableHead>
               <TableHead>Réseau social</TableHead>
               <TableHead>Auteur</TableHead>
@@ -57,6 +64,19 @@ function PostListPage() {
           <TableBody>
             {posts.map((post, index) => (
               <TableRow key={index}>
+                <TableCell>
+                  <Tooltip>
+                    <TooltipTrigger>
+                      {post.backendId && <Check className="text-green-500" />}
+                      {!post.backendId && <X className="text-red-500" />}
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {post.backendId && "Traitement effectué avec succès"}
+                      {!post.backendId && "Echec du traitement"}
+                    </TooltipContent>
+                  </Tooltip>
+                </TableCell>
+                <TableCell> {post.scrapedAt}</TableCell>
                 <TableCell> {post.scrapedAt}</TableCell>
                 <TableCell> {post.socialNetwork}</TableCell>
                 <TableCell> {post.author.name}</TableCell>

--- a/browser-extension/src/entrypoints/posts/main.tsx
+++ b/browser-extension/src/entrypoints/posts/main.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "@/styles/global.css";
 import App from "./App.tsx";
+import { TooltipProvider } from "@/components/ui/tooltip.tsx";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <TooltipProvider>
+      <App />
+    </TooltipProvider>
   </React.StrictMode>,
 );

--- a/browser-extension/src/shared/model/post.ts
+++ b/browser-extension/src/shared/model/post.ts
@@ -2,16 +2,16 @@ import { SocialNetworkName } from "./social-network-name";
 
 export type Post = {
   /**
-   * Unique id of post returned by backend after storage. 
-   * Not to be confused with postId which is the id of the post on the social network (e.g. youtube video id). 
+   * Unique id of post returned by backend after storage.
+   * Not to be confused with postId which is the id of the post on the social network (e.g. youtube video id).
    */
   backendId: string;
-  
+
   /**
    * Url of the post. E.g. youtube video url
    */
   url: string;
-  
+
   /**
    * Publication date as a string.
    * Preferably an iso datetime.

--- a/browser-extension/src/shared/model/post.ts
+++ b/browser-extension/src/shared/model/post.ts
@@ -1,7 +1,17 @@
 import { SocialNetworkName } from "./social-network-name";
 
 export type Post = {
+  /**
+   * Unique id of post returned by backend after storage. 
+   * Not to be confused with postId which is the id of the post on the social network (e.g. youtube video id). 
+   */
+  backendId: string;
+  
+  /**
+   * Url of the post. E.g. youtube video url
+   */
   url: string;
+  
   /**
    * Publication date as a string.
    * Preferably an iso datetime.

--- a/browser-extension/src/shared/storage/posts-storage.ts
+++ b/browser-extension/src/shared/storage/posts-storage.ts
@@ -9,6 +9,19 @@ export async function storePost(post: Post) {
   await browser.storage.local.set({ posts: newPosts });
 }
 
+export async function setPostBackendId(postId: string,  scrapedAt: string, backendId: string) {
+  const posts: Post[] = await getPosts();
+  const updatedPosts = posts.map(post => {
+    // Set the backendId of the post matching the postId and scrapedAt date
+    if (post.postId === postId && post.scrapedAt === scrapedAt) {
+      return { ...post, backendId };
+    }
+    return post;
+  });
+
+  await browser.storage.local.set({ posts: updatedPosts });
+}
+
 export async function getPosts(): Promise<Post[]> {
   const partial = await browser.storage.local.get("posts");
   return (partial["posts"] as Post[]) || [];

--- a/browser-extension/src/shared/storage/posts-storage.ts
+++ b/browser-extension/src/shared/storage/posts-storage.ts
@@ -9,9 +9,13 @@ export async function storePost(post: Post) {
   await browser.storage.local.set({ posts: newPosts });
 }
 
-export async function setPostBackendId(postId: string,  scrapedAt: string, backendId: string) {
+export async function setPostBackendId(
+  postId: string,
+  scrapedAt: string,
+  backendId: string,
+) {
   const posts: Post[] = await getPosts();
-  const updatedPosts = posts.map(post => {
+  const updatedPosts = posts.map((post) => {
     // Set the backendId of the post matching the postId and scrapedAt date
     if (post.postId === postId && post.scrapedAt === scrapedAt) {
       return { ...post, backendId };


### PR DESCRIPTION
- Création d'une nouvelle propriété backendId de l'entité Post côté FrontEnd pour stocker l'id fourni par le backend
- Ajout de l'indication du succès du traitement dans la liste des posts et le détail 
  - Condition booléenne basée sur l'existence de backendId
- Ajout d'une action "Relancer le traitement" permettant de soumettre de nouveau les données d'un post stocké dans le navigateur au backend
  - Passe par l'ajout d'un nouveau message au background "reprocess-post"

Je suis resté assez simple avec une notion de statut en mode boolean. Tant que le traitement backend n'est pas présent, je voyais mal une notion d'avancement possible. 