### PR TITLE
chore: exclude python 3.14 for lingua-language-detector cannot be ins…

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,7 +3,7 @@ name = "balanceteshaters"
 version = "0.1.0"
 description = "Balance tes haters"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.14"
 dependencies = [
     "alembic>=1.17.2",
     "argon2-cffi>=25.1.0",


### PR DESCRIPTION
…talled with it yet