### PR TITLE
fix: avoid errors and add default empty string

### DIFF
--- a/browser-extension/src/lib/utils.ts
+++ b/browser-extension/src/lib/utils.ts
@@ -2,5 +2,5 @@ import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-    return twMerge(clsx(inputs));
+  return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
Fixes #110
in case the comment is empty, defaults with empty string. In some cases, the comments container is not the third but the second div.