### PR TITLE
Use typescript-eslint:recommendedTypeChecked rules

### DIFF
--- a/browser-extension/e2e/utils/findTabIdForUrl.ts
+++ b/browser-extension/e2e/utils/findTabIdForUrl.ts
@@ -7,7 +7,7 @@ export async function findTabIdForUrl(
 ): Promise<number | undefined> {
   return await evaluateInBackgroundWorker<number | undefined>(
     context,
-    async (tabUrl) => {
+    async (tabUrl: string) => {
       console.log("finding tab id with url:" + tabUrl);
       const queryOptions = { url: tabUrl };
       const [tab] = await browser.tabs.query(queryOptions);

--- a/browser-extension/e2e/utils/openAndPrepareYoutubePage.ts
+++ b/browser-extension/e2e/utils/openAndPrepareYoutubePage.ts
@@ -16,7 +16,7 @@ export async function openAndPrepareYoutubeVideoPage(
 }
 
 async function closeCookieDialogIfPresent(youtubePage: Page) {
-  const closeCookieDialog = await youtubePage
+  const closeCookieDialog = youtubePage
     .getByRole("button")
     .filter({ hasText: /Reject all|Tout refuser/ });
   if (await closeCookieDialog.isVisible()) {

--- a/browser-extension/eslint.config.ts
+++ b/browser-extension/eslint.config.ts
@@ -18,7 +18,14 @@ export default defineConfig([
   configPrettier,
   eslint.configs.recommended,
   markdown.configs.processor,
-  tseslint.configs.recommended,
+  tseslint.configs.recommendedTypeChecked,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+      },
+    },
+  },
   {
     rules: {
       "@typescript-eslint/no-unused-vars": [

--- a/browser-extension/src/entrypoints/background/classification/api/__tests__/getClassificationResult.test.ts
+++ b/browser-extension/src/entrypoints/background/classification/api/__tests__/getClassificationResult.test.ts
@@ -44,7 +44,7 @@ describe("getClassificationResult", () => {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
-          "x-token": expect.any(String),
+          "x-token": expect.any(String) as string,
         },
       }),
     );
@@ -76,7 +76,7 @@ describe("getClassificationResult", () => {
         method: "GET",
         headers: {
           "Content-Type": "application/json",
-          "x-token": expect.any(String),
+          "x-token": expect.any(String) as string,
         },
       },
     );

--- a/browser-extension/src/entrypoints/background/classification/api/__tests__/submitClassificationRequest.test.ts
+++ b/browser-extension/src/entrypoints/background/classification/api/__tests__/submitClassificationRequest.test.ts
@@ -70,7 +70,7 @@ describe("postClassificationRequest", () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          "x-token": expect.any(String),
+          "x-token": expect.any(String) as string,
         },
         body: JSON.stringify(mockRequest),
       }),

--- a/browser-extension/src/entrypoints/background/classification/api/apiToken.ts
+++ b/browser-extension/src/entrypoints/background/classification/api/apiToken.ts
@@ -1,2 +1,2 @@
 export const apiToken =
-  import.meta.env.VITE_BACKEND_API_TOKEN || "<not defined>";
+  (import.meta.env.VITE_BACKEND_API_TOKEN as string) || "<not defined>";

--- a/browser-extension/src/entrypoints/background/classification/api/baseUrl.ts
+++ b/browser-extension/src/entrypoints/background/classification/api/baseUrl.ts
@@ -1,3 +1,3 @@
 export const apiBaseUrl =
-  import.meta.env.VITE_BACKEND_API_BASE_URL ||
+  (import.meta.env.VITE_BACKEND_API_BASE_URL as string | undefined) ||
   "https://balanceteshaters-app.services.d4g.fr";

--- a/browser-extension/src/entrypoints/background/classification/api/getClassificationResult.ts
+++ b/browser-extension/src/entrypoints/background/classification/api/getClassificationResult.ts
@@ -43,7 +43,7 @@ export async function getClassificationResult(
   });
 
   if (response.ok) {
-    const data = await response.json();
+    const data = (await response.json()) as unknown;
     return ClassificationResult.parse(data);
   } else {
     throw new ClassificationApiError(response.status, await response.text());

--- a/browser-extension/src/entrypoints/background/classification/api/submitClassificationRequest.ts
+++ b/browser-extension/src/entrypoints/background/classification/api/submitClassificationRequest.ts
@@ -40,7 +40,7 @@ export async function postClassificationRequest(
   });
 
   if (response.ok) {
-    const data = await response.json();
+    const data = (await response.json()) as unknown;
     return ClassificationResponse.parse(data);
   } else {
     throw new ClassificationApiError(response.status, await response.text());

--- a/browser-extension/src/entrypoints/background/classification/classificationPolling.ts
+++ b/browser-extension/src/entrypoints/background/classification/classificationPolling.ts
@@ -13,10 +13,10 @@ export function startClassificationPolling(
 ): void {
   browser.alarms.onAlarm.addListener((alarm) => {
     if (alarm.name === CLASSIFICATION_POLLING_ALARM_NAME) {
-      onClassificationPollingAlarm();
+      void onClassificationPollingAlarm();
     }
   });
-  browser.alarms.create(CLASSIFICATION_POLLING_ALARM_NAME, {
+  void browser.alarms.create(CLASSIFICATION_POLLING_ALARM_NAME, {
     delayInMinutes: 1, // First run after 1 minute
     periodInMinutes: pollingIntervalMinutes, // Then every CLASSIFICATION_POLLING_INTERVAL_MINUTES minutes
   });

--- a/browser-extension/src/entrypoints/background/classification/notifyClassificationCompleted.ts
+++ b/browser-extension/src/entrypoints/background/classification/notifyClassificationCompleted.ts
@@ -34,12 +34,12 @@ export function notifyClassificationCompleted(
       {
         title: openResultsButtonTitle,
         onClick: () => {
-          browser.tabs.create({ url: resultsUrl, active: true });
+          void browser.tabs.create({ url: resultsUrl, active: true });
         },
       },
     ],
     onClick: () => {
-      browser.tabs.create({ url: resultsUrl, active: true });
+      void browser.tabs.create({ url: resultsUrl, active: true });
     },
   });
 }
@@ -92,7 +92,8 @@ function createNotification({
   const buttonsWithoutExtraOnClick = buttons.map(
     ({ onClick: _, ...withoutOnClick }) => withoutOnClick,
   );
-  browser.notifications.create(id, {
+  //Create notification and don't wait for the result
+  void browser.notifications.create(id, {
     type: "basic",
     title,
     message,

--- a/browser-extension/src/entrypoints/background/index.ts
+++ b/browser-extension/src/entrypoints/background/index.ts
@@ -38,17 +38,17 @@ function handleIncomingMessages(
   console.debug("Background - Message received:", message, sender);
 
   if (isScrapTabMessage(message)) {
-    scrapTabAndSubmitClassificationRequest(message.tabId).then(() =>
+    void scrapTabAndSubmitClassificationRequest(message.tabId).then(() =>
       sendResponse(undefined),
     );
     return true;
   } else if (isScreenshotSenderTab(message)) {
-    screenshotSenderTab(sender).then((result) => {
+    void screenshotSenderTab(sender).then((result) => {
       sendResponse(result);
     });
     return true;
   } else if (isSubmitClassificationRequestMessage(message)) {
-    submitClassificationRequestForPost(message.postSnapshotId).then(
+    void submitClassificationRequestForPost(message.postSnapshotId).then(
       () => {
         sendResponse({ success: true });
       },

--- a/browser-extension/src/entrypoints/instagram.content/InstagramScraper.ts
+++ b/browser-extension/src/entrypoints/instagram.content/InstagramScraper.ts
@@ -7,8 +7,8 @@ import { ScrapingSupport } from "@/shared/scraping/ScrapingSupport";
 import { ProgressManager } from "@/shared/scraping-content-script/ProgressManager";
 
 export class InstagramScraper implements SocialNetworkScraper {
-  async getSocialNetworkPageInfo(): Promise<SocialNetworkPageInfo> {
-    return instagramPageInfo(document.URL);
+  getSocialNetworkPageInfo(): Promise<SocialNetworkPageInfo> {
+    return Promise.resolve(instagramPageInfo(document.URL));
   }
 
   async scrapPagePost(

--- a/browser-extension/src/entrypoints/instagram.content/instagram-post-native-scraper.ts
+++ b/browser-extension/src/entrypoints/instagram.content/instagram-post-native-scraper.ts
@@ -24,7 +24,7 @@ type CommentThread =
 export class InstagramPostNativeScraper {
   public constructor(private scrapingSupport: ScrapingSupport) {}
 
-  private debug(...data: typeof console.debug.arguments) {
+  private debug(...data: unknown[]) {
     console.debug(LOG_PREFIX, ...data);
   }
 
@@ -50,7 +50,7 @@ export class InstagramPostNativeScraper {
 
     this.debug("Scraping publishedAt...");
     const publishedAt = this.scrapPostPublishedAt(postElements.scrollableArea);
-    this.debug(`publishedAt: ${publishedAt}`);
+    this.debug(`publishedAt: ${JSON.stringify(publishedAt)}`);
 
     this.debug("Scraping comments...");
     const comments: CommentSnapshot[] = await this.scrapPostComments(
@@ -172,7 +172,7 @@ export class InstagramPostNativeScraper {
     // Make sure every comment is scraped.
     // I think it should not be that different from the processing of the youtube scraper.
     while (spinner) {
-      this.scrapingSupport.resumeHostPage(); // throws if aborted
+      await this.scrapingSupport.resumeHostPage(); // throws if aborted
 
       spinner.scrollIntoView();
       // Wait a bit to let page load stuff

--- a/browser-extension/src/entrypoints/popup/Popup.tsx
+++ b/browser-extension/src/entrypoints/popup/Popup.tsx
@@ -27,7 +27,7 @@ function PopupContent() {
     const parsedUrl = URL.parse(document.URL);
     const tabUrl = parsedUrl?.hash?.substring(1);
     const tabPromise = tabUrl ? queryTabWithUrl(tabUrl) : queryActiveTab();
-    tabPromise.then((tab) => setTabId(tab?.id));
+    void tabPromise.then((tab) => setTabId(tab?.id));
   });
 
   const {
@@ -100,7 +100,7 @@ function StartScrapingButton({ tabId }: { tabId: number }) {
     <Button
       data-testid="start-scraping-button"
       className="w-full"
-      onClick={() => handleStartScrapingClick(tabId)}
+      onClick={() => void handleStartScrapingClick(tabId)}
     >
       Analyser cette publication
     </Button>

--- a/browser-extension/src/entrypoints/posts/DebugPage.tsx
+++ b/browser-extension/src/entrypoints/posts/DebugPage.tsx
@@ -3,13 +3,13 @@ import { STORAGE_KEY_DEBUG_FP_SCREENSHOT_DATAURL } from "@/shared/native-screens
 
 function downloadLatestFullPageScreenshot() {
   console.log("Downloading latestFullPageScreenshot");
-  browser.storage.local
+  void browser.storage.local
     .get(STORAGE_KEY_DEBUG_FP_SCREENSHOT_DATAURL)
     .then((partial) => {
       const dataUrl = partial[
         STORAGE_KEY_DEBUG_FP_SCREENSHOT_DATAURL
       ] as string;
-      browser.downloads.download({
+      return browser.downloads.download({
         url: dataUrl,
         filename: "screenshot.png",
       });

--- a/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
@@ -283,7 +283,7 @@ export default function CommentsTable({
       onSubmit={(e) => {
         e.preventDefault();
         e.stopPropagation();
-        form.handleSubmit();
+        void form.handleSubmit();
       }}
     >
       <div className="p-3 flex justify-between">

--- a/browser-extension/src/entrypoints/posts/Report/Step1Plateforme.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Step1Plateforme.tsx
@@ -20,11 +20,11 @@ function Step1Plateforme({
     },
     onSubmit: () => {
       setSocialNetworkList(form.state.values.socialNetworkList);
-      stepper.navigation.next();
+      void stepper.navigation.next();
     },
   });
 
-  const options = [
+  const options: { id: string; label: string }[] = [
     { id: SocialNetwork.Instagram, label: "Instagram" },
     { id: SocialNetwork.YouTube, label: "YouTube" },
   ];
@@ -40,7 +40,7 @@ function Step1Plateforme({
         onSubmit={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          form.handleSubmit();
+          void form.handleSubmit();
         }}
         className="space-y-6 p-4 flex justify-center"
       >

--- a/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
@@ -50,7 +50,7 @@ function Step2Posts({
     },
     onSubmit: () => {
       setPostList(form.state.values.postList);
-      stepper.navigation.next();
+      void stepper.navigation.next();
     },
   });
 
@@ -75,7 +75,7 @@ function Step2Posts({
         onSubmit={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          form.handleSubmit();
+          void form.handleSubmit();
         }}
         className="space-y-6 p-4 flex justify-center"
       >

--- a/browser-extension/src/entrypoints/posts/Report/Step3Comments.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Step3Comments.tsx
@@ -39,7 +39,7 @@ function Step3Comments({
     setCommentList(
       allComments.filter((comment) => commentIdList.includes(comment.id)),
     );
-    stepper.navigation.next();
+    void stepper.navigation.next();
   };
 
   console.log("render Step3Comments : ", { allComments, reportQueryData });

--- a/browser-extension/src/entrypoints/scraping-sidepanel/DisplayScrapingInProgress.tsx
+++ b/browser-extension/src/entrypoints/scraping-sidepanel/DisplayScrapingInProgress.tsx
@@ -37,7 +37,7 @@ export function DisplayScrapingInProgress({
           className="w-full"
           variant="destructive"
           onClick={() =>
-            new ScrapingContentScriptClient(tabInfo.tabId).cancelScraping()
+            void new ScrapingContentScriptClient(tabInfo.tabId).cancelScraping()
           }
         >
           Arrêter l&apos;analyse

--- a/browser-extension/src/entrypoints/scraping-sidepanel/startScraping.tsx
+++ b/browser-extension/src/entrypoints/scraping-sidepanel/startScraping.tsx
@@ -5,5 +5,5 @@ export function startScraping(tabId: number) {
     msgType: "scrap-tab",
     tabId: tabId,
   };
-  browser.runtime.sendMessage(message);
+  void browser.runtime.sendMessage(message);
 }

--- a/browser-extension/src/entrypoints/scraping-sidepanel/useScrapingAndClassificationTabInfo.tsx
+++ b/browser-extension/src/entrypoints/scraping-sidepanel/useScrapingAndClassificationTabInfo.tsx
@@ -56,7 +56,7 @@ export function useScrapingAndClassificationTabInfo(
     ) => {
       if (changedTabId === tabId && changeInfo.url) {
         // Trigger query on tab url change to keep side panel content
-        queryClient.invalidateQueries({
+        void queryClient.invalidateQueries({
           queryKey: scrapingAndClassificationTabInfoQueryKey(tabId),
         });
       }

--- a/browser-extension/src/entrypoints/youtube.content/YoutubeScraper.ts
+++ b/browser-extension/src/entrypoints/youtube.content/YoutubeScraper.ts
@@ -7,8 +7,8 @@ import { ScrapingSupport } from "@/shared/scraping/ScrapingSupport";
 import { ProgressManager } from "@/shared/scraping-content-script/ProgressManager";
 
 export class YoutubeScraper implements SocialNetworkScraper {
-  async getSocialNetworkPageInfo(): Promise<SocialNetworkPageInfo> {
-    return youtubePageInfo(document.URL);
+  getSocialNetworkPageInfo(): Promise<SocialNetworkPageInfo> {
+    return Promise.resolve(youtubePageInfo(document.URL));
   }
 
   async scrapPagePost(

--- a/browser-extension/src/entrypoints/youtube.content/youtube-post-native-scrapper.ts
+++ b/browser-extension/src/entrypoints/youtube.content/youtube-post-native-scrapper.ts
@@ -35,13 +35,13 @@ type CommentThread =
 export class YoutubePostNativeScrapper {
   public constructor(private scrapingSupport: ScrapingSupport) {}
 
-  private debug(...data: typeof console.debug.arguments) {
+  private debug(...data: unknown[]) {
     console.debug(LOG_PREFIX, ...data);
   }
-  private info(...data: typeof console.debug.arguments) {
+  private info(...data: unknown[]) {
     console.info(LOG_PREFIX, ...data);
   }
-  private warn(...data: typeof console.debug.arguments) {
+  private warn(...data: unknown[]) {
     console.warn(LOG_PREFIX, ...data);
   }
 
@@ -78,7 +78,7 @@ export class YoutubePostNativeScrapper {
 
     this.debug("Scraping publishedAt...");
     const publishedAt = await this.scrapPostPublishedAt();
-    this.debug(`publishedAt: ${publishedAt}`);
+    this.debug(`publishedAt: ${JSON.stringify(publishedAt)}`);
 
     // Init accounts for 1%
     progressManager.setProgress(1);
@@ -355,7 +355,7 @@ export class YoutubePostNativeScrapper {
       };
     }
 
-    const comment = await this.scrapCommentWithoutReplies(
+    const comment = this.scrapCommentWithoutReplies(
       commentContainer,
       fullPageScreenshot,
     );
@@ -616,13 +616,13 @@ export class YoutubePostNativeScrapper {
     }
   }
 
-  private async scrapCommentWithoutReplies(
+  private scrapCommentWithoutReplies(
     commentContainer: HTMLElement,
     fullPageScreenshot: FullPageScreenshotResult,
-  ): Promise<CommentSnapshot> {
+  ): CommentSnapshot {
     const scrapDate = currentIsoDate();
 
-    const author: Author = await this.scrapCommentAuthor(commentContainer);
+    const author: Author = this.scrapCommentAuthor(commentContainer);
     const publishedTimeElement = this.scrapingSupport.selectOrThrow(
       commentContainer,
       "#published-time-text",
@@ -630,7 +630,7 @@ export class YoutubePostNativeScrapper {
     );
     const publishedAtText = publishedTimeElement.innerText;
     const publishedAt = new PublicationDateTextParsing(publishedAtText).parse();
-    this.debug(`publishedAtInfo: ${publishedAt}`);
+    this.debug(`publishedAtInfo: ${JSON.stringify(publishedAt)}`);
 
     const commentHref = this.scrapingSupport.selectOrThrow(
       publishedTimeElement,
@@ -684,9 +684,7 @@ export class YoutubePostNativeScrapper {
     };
   }
 
-  private async scrapCommentAuthor(
-    commentContainer: HTMLElement,
-  ): Promise<Author> {
+  scrapCommentAuthor(commentContainer: HTMLElement): Author {
     const authorTextHandle = this.scrapingSupport.selectOrThrow(
       commentContainer,
       "a#author-text",

--- a/browser-extension/src/shared/native-screenshoting/cs/screenshot-cs-tab.ts
+++ b/browser-extension/src/shared/native-screenshoting/cs/screenshot-cs-tab.ts
@@ -1,10 +1,12 @@
-import { TabScreenshotResult } from "../background/screenshot-sender-tab";
-import { TAB_SCREENSHOT_MSG } from "../message";
+import { type TabScreenshotResult } from "../background/screenshot-sender-tab";
+import { TAB_SCREENSHOT_MSG, type TabScreenshotMessage } from "../message";
 
 export async function captureTabScreenshotAsDataUrl(): Promise<string> {
-  const result = (await browser.runtime.sendMessage(
-    TAB_SCREENSHOT_MSG,
-  )) as TabScreenshotResult;
+  const result = await browser.runtime.sendMessage<
+    TabScreenshotMessage,
+    TabScreenshotResult
+  >(TAB_SCREENSHOT_MSG);
+
   if (typeof result === "string") {
     return result;
   }

--- a/browser-extension/src/shared/scraping-content-script/ScrapingContentScript.ts
+++ b/browser-extension/src/shared/scraping-content-script/ScrapingContentScript.ts
@@ -41,21 +41,21 @@ export class ScrapingContentScript {
     sendResponse: (response?: unknown) => void,
   ): true | undefined {
     if (isScsPageInfoMessage(message)) {
-      this.getPageInfo().then(sendResponse);
+      void this.getPageInfo().then(sendResponse);
       // Return true to indicate async response to web-ext-messaging
       return true;
     } else if (isScsScrapTabMessage(message)) {
-      this.scrapPost().then(sendResponse);
+      void this.scrapPost().then(sendResponse);
       // Return true to indicate async response to web-ext-messaging
       return true;
     } else if (isScsGetScrapingStatusMessage(message)) {
-      this.getScrapingStatus().then(sendResponse);
+      void this.getScrapingStatus().then(sendResponse);
       // Return true to indicate async response to web-ext-messaging
       return true;
     } else if (isScsCancelScrapTabMessage(message)) {
-      this.cancelScraping().then(sendResponse);
-      // Return true to indicate async response to web-ext-messaging
-      return true;
+      this.cancelScraping();
+      sendResponse();
+      return;
     }
   }
 
@@ -149,7 +149,7 @@ export class ScrapingContentScript {
     }
   }
 
-  private async cancelScraping(): Promise<void> {
+  private cancelScraping(): void {
     if (this.scrapingStatus.type !== "running" || !this.scrapAbortController) {
       console.info("[SCS] - No scraping in progress to cancel");
       return;

--- a/browser-extension/src/shared/scraping-content-script/ScrapingContentScriptClient.ts
+++ b/browser-extension/src/shared/scraping-content-script/ScrapingContentScriptClient.ts
@@ -73,10 +73,9 @@ export class ScrapingContentScriptClient {
    * Cancel the currently running scraping operation for this tab
    */
   async cancelScraping(): Promise<void> {
-    const response = await this.safeSendMessage<
-      ScsCancelScrapTabMessage,
-      ScrapingResult
-    >(SCS_CANCEL_SCRAP_TAB_MESSAGE);
+    const response = await this.safeSendMessage<ScsCancelScrapTabMessage, null>(
+      SCS_CANCEL_SCRAP_TAB_MESSAGE,
+    );
     if (response === NO_CONTENT_SCRIPT) {
       throw new Error("No Scraping Content script registered for this url");
     }

--- a/browser-extension/src/shared/scraping/ScrapingSupport.ts
+++ b/browser-extension/src/shared/scraping/ScrapingSupport.ts
@@ -111,7 +111,7 @@ export class ScrapingSupport {
         "Failed to select element matching selector " +
         selector +
         " and predicate " +
-        options?.predicate +
+        String(options?.predicate) +
         " before timeout",
     };
   }
@@ -147,7 +147,7 @@ export class ScrapingSupport {
       if (Date.now() - start > timeout) {
         throw new Error(
           `Still ${visibleElements.length} elements matching selection at timeout.` +
-            ` Selector:${selector}, Predicate ${options?.extraPredicate}, Timeout :(${timeout}ms)`,
+            ` Selector:${selector}, Predicate ${String(options?.extraPredicate)}, Timeout :(${timeout}ms)`,
         );
       }
 

--- a/browser-extension/src/shared/utils/__tests__/withRetry.test.ts
+++ b/browser-extension/src/shared/utils/__tests__/withRetry.test.ts
@@ -162,12 +162,12 @@ describe("withRetry", () => {
 
       expect(beforeRetry).toHaveBeenCalledTimes(2);
       expect(beforeRetry).toHaveBeenNthCalledWith(1, {
-        latestError: expect.any(Error),
+        latestError: expect.any(Error) as Error,
         failedAttempts: 1,
         remainingAttempts: 2,
       });
       expect(beforeRetry).toHaveBeenNthCalledWith(2, {
-        latestError: expect.any(Error),
+        latestError: expect.any(Error) as Error,
         failedAttempts: 2,
         remainingAttempts: 1,
       });

--- a/browser-extension/src/shared/utils/createLogger.ts
+++ b/browser-extension/src/shared/utils/createLogger.ts
@@ -1,0 +1,29 @@
+export type Logger = {
+  debug: (...data: LogArgs) => void;
+  warn: (...data: LogArgs) => void;
+  info: (...data: LogArgs) => void;
+  error: (...data: LogArgs) => void;
+  log: (...data: LogArgs) => void;
+};
+
+export type LogArgs = unknown[];
+
+/**
+ * Creates a simple prefixed logger.
+ * TODO consider using winston
+ * @param loggerPrefix
+ * @param baseLogger
+ * @returns
+ */
+export function createLogger(
+  loggerPrefix: string,
+  baseLogger: Logger = console,
+): Logger {
+  return {
+    debug: (...data: LogArgs) => baseLogger.debug(loggerPrefix, ...data),
+    warn: (...data: LogArgs) => baseLogger.warn(loggerPrefix, ...data),
+    info: (...data: LogArgs) => baseLogger.info(loggerPrefix, ...data),
+    error: (...data: LogArgs) => baseLogger.error(loggerPrefix, ...data),
+    log: (...data: LogArgs) => baseLogger.log(loggerPrefix, ...data),
+  };
+}


### PR DESCRIPTION
Use stricter eslint config to allow detection of missing awaits
* Switch eslint config from typescript-eslint:recommended to recommendedTypeChecked
* Adapt code to new rules mostly:
  * handling floating promises
  * stricter rules preventing use of type any

Fixes [#215](https://github.com/dataforgoodfr/14_BalanceTesHaters/issues/215)