### PR TITLE
fix: Instagram comment screenshots in scraping and report step

### DIFF
--- a/browser-extension/src/entrypoints/instagram.content/InstagramScraper.ts
+++ b/browser-extension/src/entrypoints/instagram.content/InstagramScraper.ts
@@ -13,12 +13,14 @@ export class InstagramScraper implements SocialNetworkScraper {
 
   async scrapPagePost(
     abortSignal: AbortSignal,
-    _: ProgressManager,
+    progressManager: ProgressManager,
   ): Promise<PostSnapshot> {
     // Note by @sarod:
     // Code delegates to InstagramPostNativeScraper rather than merge them in a single class
     // to minimize merge conflicts but these could be merged later
     const scrapingSupport = new ScrapingSupport(abortSignal);
-    return new InstagramPostNativeScraper(scrapingSupport).scrapPost();
+    return new InstagramPostNativeScraper(scrapingSupport).scrapPost(
+      progressManager,
+    );
   }
 }

--- a/browser-extension/src/entrypoints/instagram.content/instagram-comment-screenshot-capture.ts
+++ b/browser-extension/src/entrypoints/instagram.content/instagram-comment-screenshot-capture.ts
@@ -1,0 +1,203 @@
+import { captureTabScreenshotAsDataUrl } from "@/shared/native-screenshoting/cs/screenshot-cs-tab";
+import { CommentSnapshot } from "@/shared/model/PostSnapshot";
+import { ProgressManager } from "@/shared/scraping-content-script/ProgressManager";
+import { ScrapingSupport } from "@/shared/scraping/ScrapingSupport";
+import { base64ToUint8Array, uint8ArrayToBase64 } from "@/shared/utils/base-64";
+import { extractBase64DataFromDataUrl } from "@/shared/utils/data-url";
+import { decodePng, encodePng } from "image-js";
+
+const LOG_PREFIX = "[CS - InstagramCommentScreenshotCapture] ";
+
+type CaptureInstagramCommentScreenshotsParams = {
+  comments: CommentSnapshot[];
+  commentElementsById: Map<string, HTMLElement>;
+  scrapingSupport: ScrapingSupport;
+  progressManager: ProgressManager;
+  debug?: (...data: unknown[]) => void;
+};
+
+export async function captureInstagramCommentScreenshots({
+  comments,
+  commentElementsById,
+  scrapingSupport,
+  progressManager,
+  debug,
+}: CaptureInstagramCommentScreenshotsParams): Promise<void> {
+  const log = (...data: unknown[]) =>
+    (debug ?? console.debug)(LOG_PREFIX, ...data);
+  const warn = (...data: unknown[]) => console.warn(LOG_PREFIX, ...data);
+
+  const flatComments = flattenComments(comments);
+  if (flatComments.length === 0) {
+    progressManager.setProgress(100);
+    return;
+  }
+
+  const perCommentProgress = progressManager.subTaskProgressManager({
+    from: 0,
+    to: 100,
+  });
+
+  for (let i = 0; i < flatComments.length; i += 1) {
+    const comment = flatComments[i];
+    try {
+      await scrapingSupport.resumeHostPage();
+
+      const targetElement = commentElementsById.get(comment.id);
+      if (!targetElement) {
+        continue;
+      }
+
+      const screenshotElement = resolveScreenshotElement(targetElement);
+      screenshotElement.scrollIntoView({
+        block: "center",
+        inline: "nearest",
+      });
+      await scrapingSupport.sleep(150);
+
+      const screenshotDataUrl = await captureTabScreenshotAsDataUrl();
+      const screenshotData = cropVisibleElementAsPngBase64(
+        screenshotElement,
+        screenshotDataUrl,
+      );
+      if (screenshotData) {
+        comment.screenshotData = screenshotData;
+      }
+    } catch (e) {
+      warn("Failed to capture screenshot for Instagram comment", {
+        commentId: comment.id,
+        error: String(e),
+      });
+    } finally {
+      perCommentProgress.setProgress(((i + 1) / flatComments.length) * 100);
+    }
+  }
+
+  log(
+    `Captured screenshots for ${flatComments.filter((c) => c.screenshotData).length}/${flatComments.length} comments`,
+  );
+}
+
+function flattenComments(comments: CommentSnapshot[]): CommentSnapshot[] {
+  return comments.flatMap((comment) => [
+    comment,
+    ...flattenComments(comment.replies),
+  ]);
+}
+
+function resolveScreenshotElement(element: HTMLElement): HTMLElement {
+  let fallbackCandidate: HTMLElement | undefined;
+  let current: HTMLElement | null = element;
+  for (let i = 0; i < 6 && current; i += 1) {
+    if (isValidCommentCaptureContainer(current)) {
+      return current;
+    }
+    if (!fallbackCandidate && isFallbackCaptureContainer(current)) {
+      fallbackCandidate = current;
+    }
+    const nextParentElement: HTMLElement | null = current.parentElement;
+    if (!nextParentElement || nextParentElement === document.body) {
+      break;
+    }
+    current = nextParentElement;
+  }
+
+  return fallbackCandidate ?? element;
+}
+
+function isValidCommentCaptureContainer(element: HTMLElement): boolean {
+  const rect = element.getBoundingClientRect();
+  if (
+    rect.width < 210 ||
+    rect.width > window.innerWidth * 0.6 ||
+    rect.height < 32 ||
+    rect.height > window.innerHeight * 0.6
+  ) {
+    return false;
+  }
+  if (rect.x < window.innerWidth * 0.2) {
+    return false;
+  }
+  const timeCount = element.querySelectorAll("time[datetime]").length;
+  if (timeCount < 1 || timeCount > 3) {
+    return false;
+  }
+
+  const accountLinkCount = element.querySelectorAll("a[href^='/']").length;
+  if (accountLinkCount < 1 || accountLinkCount > 8) {
+    return false;
+  }
+
+  const nestedListCount = element.querySelectorAll("li").length;
+  if (nestedListCount > 2) {
+    return false;
+  }
+
+  return true;
+}
+
+function isFallbackCaptureContainer(element: HTMLElement): boolean {
+  const rect = element.getBoundingClientRect();
+  if (rect.width < 180 || rect.height < 24) {
+    return false;
+  }
+  if (rect.width > window.innerWidth * 0.72) {
+    return false;
+  }
+  if (rect.height > window.innerHeight * 0.82) {
+    return false;
+  }
+  return true;
+}
+
+function cropVisibleElementAsPngBase64(
+  element: HTMLElement,
+  screenshotDataUrl: string,
+): string | undefined {
+  const image = decodePng(
+    base64ToUint8Array(extractBase64DataFromDataUrl(screenshotDataUrl)),
+  );
+  const rect = element.getBoundingClientRect();
+  if (rect.width <= 1 || rect.height <= 1) {
+    return undefined;
+  }
+
+  const paddingX = 12;
+  const paddingY = 8;
+  const leftCss = Math.max(0, rect.x - paddingX);
+  const topCss = Math.max(0, rect.y - paddingY);
+  const rightCss = Math.min(window.innerWidth, rect.x + rect.width + paddingX);
+  const bottomCss = Math.min(
+    window.innerHeight,
+    rect.y + rect.height + paddingY,
+  );
+  if (rightCss <= leftCss || bottomCss <= topCss) {
+    return undefined;
+  }
+
+  // captureVisibleTab can return an image in device pixels (HiDPI),
+  // while getBoundingClientRect uses CSS pixels. Convert coordinates.
+  const scaleX = image.width / window.innerWidth;
+  const scaleY = image.height / window.innerHeight;
+
+  const x = Math.max(0, Math.floor(leftCss * scaleX));
+  const y = Math.max(0, Math.floor(topCss * scaleY));
+  const width = Math.min(
+    image.width - x,
+    Math.ceil((rightCss - leftCss) * scaleX),
+  );
+  const height = Math.min(
+    image.height - y,
+    Math.ceil((bottomCss - topCss) * scaleY),
+  );
+  if (width <= 0 || height <= 0) {
+    return undefined;
+  }
+
+  const cropped = image.crop({
+    origin: { column: x, row: y },
+    width,
+    height,
+  });
+  return uint8ArrayToBase64(encodePng(cropped));
+}

--- a/browser-extension/src/entrypoints/instagram.content/instagram-comment-text-utils.ts
+++ b/browser-extension/src/entrypoints/instagram.content/instagram-comment-text-utils.ts
@@ -1,0 +1,80 @@
+const UI_LABELS = new Set([
+  "like",
+  "likes",
+  "liked",
+  "j'aime",
+  "j’aime",
+  "reply",
+  "replies",
+  "répondre",
+  "options de commentaire",
+  "see translation",
+  "voir la traduction",
+  "follow",
+  "following",
+  "suivre",
+  "ago",
+]);
+
+const RESERVED_INSTAGRAM_PATH_SEGMENTS = new Set([
+  "about",
+  "accounts",
+  "api",
+  "direct",
+  "explore",
+  "legal",
+  "p",
+  "privacy",
+  "reel",
+  "reels",
+  "stories",
+]);
+
+export function normalizeInstagramText(
+  text: string | null | undefined,
+): string | undefined {
+  const normalized = text?.trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized;
+}
+
+export function looksLikeInstagramUiLabel(text: string): boolean {
+  const normalizedText = text.toLowerCase();
+  if (
+    /^\d+[.,]?\d*[km]?$/i.test(normalizedText) ||
+    /^\d+\s*(?:h|min|j|s|sem)\d*$/i.test(normalizedText)
+  ) {
+    return true;
+  }
+
+  return UI_LABELS.has(normalizedText);
+}
+
+export function sanitizeInstagramCommentText(
+  text: string | null | undefined,
+): string | undefined {
+  const normalized = normalizeInstagramText(text);
+  if (!normalized) {
+    return undefined;
+  }
+
+  const cleaned = normalized
+    .replace(/\s*(?:j['’]aime|like)\s*options de commentaire\s*$/i, "")
+    .replace(/\s*options de commentaire\s*$/i, "")
+    .trim();
+  if (!cleaned || looksLikeInstagramUiLabel(cleaned)) {
+    return undefined;
+  }
+
+  return cleaned;
+}
+
+export function isLikelyInstagramAccountPath(pathSegment: string): boolean {
+  const normalizedPathSegment = pathSegment.toLowerCase();
+  if (RESERVED_INSTAGRAM_PATH_SEGMENTS.has(normalizedPathSegment)) {
+    return false;
+  }
+  return /^[a-z0-9._]{1,30}$/i.test(pathSegment);
+}

--- a/browser-extension/src/entrypoints/instagram.content/instagram-post-modal-scraper.ts
+++ b/browser-extension/src/entrypoints/instagram.content/instagram-post-modal-scraper.ts
@@ -5,6 +5,14 @@ import { ScrapingSupport } from "@/shared/scraping/ScrapingSupport";
 import { Author } from "@/shared/model/Author";
 import { INSTAGRAM_URL, instagramPageInfo } from "./instagramPageInfo";
 import { SocialNetwork } from "@/shared/model/SocialNetworkName";
+import { ProgressManager } from "@/shared/scraping-content-script/ProgressManager";
+import { captureInstagramCommentScreenshots } from "./instagram-comment-screenshot-capture";
+import {
+  isLikelyInstagramAccountPath,
+  looksLikeInstagramUiLabel,
+  normalizeInstagramText,
+  sanitizeInstagramCommentText,
+} from "./instagram-comment-text-utils";
 
 const LOG_PREFIX = "[CS - InstagramPostModalScraper] ";
 const POST_TEXT_SELECTORS = [
@@ -43,26 +51,19 @@ const COMMENT_TEXT_SELECTORS = [
   ":scope h1",
   ":scope span",
 ];
-const UI_LABELS = new Set([
-  "like",
-  "likes",
-  "liked",
-  "j'aime",
-  "j’aime",
-  "reply",
-  "replies",
-  "répondre",
-  "see translation",
-  "voir la traduction",
-  "follow",
-  "following",
-  "suivre",
-  "ago",
-]);
-
 type InstagramPostElements = {
   channelHeader: HTMLElement;
   scrollableArea: HTMLElement;
+};
+
+type ScrapedComments = {
+  comments: CommentSnapshot[];
+  commentElementsById: Map<string, HTMLElement>;
+};
+
+type ScrapedLooseComment = {
+  comment: CommentSnapshot;
+  screenshotElement: HTMLElement;
 };
 
 export class InstagramPostModalScraper {
@@ -72,7 +73,7 @@ export class InstagramPostModalScraper {
     console.debug(LOG_PREFIX, ...data);
   }
 
-  async scrapPost(): Promise<PostSnapshot> {
+  async scrapPost(progressManager: ProgressManager): Promise<PostSnapshot> {
     this.debug("Start Scraping... ", document.URL);
 
     const url = document.URL;
@@ -97,9 +98,23 @@ export class InstagramPostModalScraper {
     this.debug(`publishedAt: ${JSON.stringify(publishedAt)}`);
 
     this.debug("Scraping comments...");
-    const rawComments: CommentSnapshot[] = await this.scrapPostComments(
-      postElements.scrollableArea,
-    );
+    const { comments: rawComments, commentElementsById } =
+      await this.scrapPostComments(
+        postElements.scrollableArea,
+        progressManager.subTaskProgressManager({ from: 0, to: 70 }),
+      );
+
+    this.debug("Capturing comment screenshots...");
+    await captureInstagramCommentScreenshots({
+      comments: rawComments,
+      commentElementsById,
+      scrapingSupport: this.scrapingSupport,
+      progressManager: progressManager.subTaskProgressManager({
+        from: 70,
+        to: 100,
+      }),
+      debug: this.debug.bind(this),
+    });
     const comments = rawComments.filter(
       (comment) => !this.isPostMetadataEntry(comment, author, publishedAt),
     );
@@ -185,7 +200,7 @@ export class InstagramPostModalScraper {
       throw new Error("Missing channel href");
     }
 
-    const channelName = this.normalizeText(channelElement.textContent);
+    const channelName = normalizeInstagramText(channelElement.textContent);
     if (!channelName) {
       throw new Error("Missing channel name");
     }
@@ -203,8 +218,8 @@ export class InstagramPostModalScraper {
         selector,
         HTMLElement,
       );
-      const text = this.normalizeText(textElement?.textContent);
-      if (text && !this.looksLikeUiLabel(text)) {
+      const text = normalizeInstagramText(textElement?.textContent);
+      if (text && !looksLikeInstagramUiLabel(text)) {
         return text;
       }
     }
@@ -231,25 +246,30 @@ export class InstagramPostModalScraper {
 
   private async scrapPostComments(
     scrollableArea: HTMLElement,
-  ): Promise<CommentSnapshot[]> {
+    progressManager: ProgressManager,
+  ): Promise<ScrapedComments> {
     const commentsContainer = this.selectCommentsContainer(scrollableArea);
     commentsContainer.scrollIntoView();
+    progressManager.setProgress(5);
 
     await this.loadAllTopLevelComments(commentsContainer, scrollableArea);
+    progressManager.setProgress(65);
 
-    let comments =
+    let extraction =
       this.scrapCommentHierarchyFromDatetimeMarkers(commentsContainer);
-    if (this.countAllComments(comments) <= 1) {
-      const broaderComments =
+    if (this.countAllComments(extraction.comments) <= 1) {
+      const broaderExtraction =
         this.scrapCommentHierarchyFromDatetimeMarkers(scrollableArea);
       if (
-        this.countAllComments(broaderComments) > this.countAllComments(comments)
+        this.countAllComments(broaderExtraction.comments) >
+        this.countAllComments(extraction.comments)
       ) {
-        comments = broaderComments;
+        extraction = broaderExtraction;
       }
     }
+    progressManager.setProgress(100);
 
-    return comments;
+    return extraction;
   }
 
   private selectCommentsContainer(scrollableArea: HTMLElement): HTMLElement {
@@ -487,11 +507,12 @@ export class InstagramPostModalScraper {
 
   private scrapCommentHierarchyFromDatetimeMarkers(
     root: HTMLElement,
-  ): CommentSnapshot[] {
+  ): ScrapedComments {
     const records: Array<{
       node: HTMLElement;
       parentNode?: HTMLElement;
       comment: CommentSnapshot;
+      screenshotElement: HTMLElement;
     }> = [];
     const seenNodes = new Set<HTMLElement>();
     const seenSignatures = new Set<string>();
@@ -502,7 +523,9 @@ export class InstagramPostModalScraper {
     );
 
     for (const timeElement of times) {
-      const commentElement = this.findCommentElementFromTime(timeElement);
+      const listItem = timeElement.closest("li");
+      const commentElement =
+        listItem ?? this.findCommentElementFromTime(timeElement);
       if (!commentElement) {
         continue;
       }
@@ -512,16 +535,18 @@ export class InstagramPostModalScraper {
         continue;
       }
 
-      const comment = this.scrapLooseCommentFromElement(commentElement);
-      if (!comment) {
+      const scrapedComment = this.scrapLooseCommentFromElement(commentElement);
+      if (!scrapedComment) {
         continue;
       }
 
       const signature = [
-        comment.author.accountHref,
-        comment.publishedAt.type,
-        comment.publishedAt.type === "absolute" ? comment.publishedAt.date : "",
-        comment.textContent,
+        scrapedComment.comment.author.accountHref,
+        scrapedComment.comment.publishedAt.type,
+        scrapedComment.comment.publishedAt.type === "absolute"
+          ? scrapedComment.comment.publishedAt.date
+          : "",
+        scrapedComment.comment.textContent,
       ].join("|");
       if (seenSignatures.has(signature)) {
         continue;
@@ -531,7 +556,8 @@ export class InstagramPostModalScraper {
       records.push({
         node: commentNode,
         parentNode: commentNode.parentElement?.closest("li") ?? undefined,
-        comment,
+        comment: scrapedComment.comment,
+        screenshotElement: scrapedComment.screenshotElement,
       });
     }
 
@@ -548,9 +574,11 @@ export class InstagramPostModalScraper {
 
     const topLevelComments: CommentSnapshot[] = [];
     const commentsByNode = new Map<HTMLElement, CommentSnapshot>();
+    const commentElementsById = new Map<string, HTMLElement>();
 
     for (const record of records) {
       commentsByNode.set(record.node, record.comment);
+      commentElementsById.set(record.comment.id, record.screenshotElement);
       if (record.parentNode) {
         const parentComment = commentsByNode.get(record.parentNode);
         if (parentComment) {
@@ -561,7 +589,10 @@ export class InstagramPostModalScraper {
       topLevelComments.push(record.comment);
     }
 
-    return topLevelComments;
+    return {
+      comments: topLevelComments,
+      commentElementsById,
+    };
   }
 
   private findCommentElementFromTime(
@@ -570,10 +601,7 @@ export class InstagramPostModalScraper {
     let current: HTMLElement | null = timeElement;
 
     for (let depth = 0; depth < 10 && current; depth += 1) {
-      if (
-        this.scrapAuthorFromContainer(current) &&
-        this.extractCommentText(current)
-      ) {
+      if (this.isLikelyCommentElement(current)) {
         return current;
       }
       current = current.parentElement;
@@ -582,36 +610,65 @@ export class InstagramPostModalScraper {
     return undefined;
   }
 
+  private isLikelyCommentElement(element: HTMLElement): boolean {
+    const author = this.scrapAuthorFromContainer(element);
+    const commentText = this.extractCommentText(element, author?.name).text;
+    if (!author || !commentText) {
+      return false;
+    }
+
+    const timeCount = this.scrapingSupport.selectAll(
+      element,
+      "time[datetime]",
+      HTMLElement,
+    ).length;
+    if (timeCount > 3) {
+      return false;
+    }
+
+    return !this.scrapingSupport.select(element, "header", HTMLElement);
+  }
+
   private scrapLooseCommentFromElement(
     commentElement: HTMLElement,
-  ): CommentSnapshot | undefined {
+  ): ScrapedLooseComment | undefined {
     const author = this.scrapAuthorFromContainer(commentElement);
     const publishedAt = this.scrapPublishedAtFromContainer(commentElement);
-    const text = this.extractCommentText(commentElement, author?.name);
+    const extractedText = this.extractCommentText(commentElement, author?.name);
+    const text = extractedText.text;
 
     if (!author || !publishedAt || !text) {
       return undefined;
     }
-    if (text === author.name || this.looksLikeUiLabel(text)) {
+    if (text === author.name || looksLikeInstagramUiLabel(text)) {
       return undefined;
     }
 
-    return {
+    const comment: CommentSnapshot = {
       id: crypto.randomUUID(),
       author,
       textContent: text,
       publishedAt,
+      // Filled later during screenshot capture phase.
       screenshotData: "",
       scrapedAt: currentIsoDate(),
       replies: [],
       nbLikes: 0, // See https://github.com/dataforgoodfr/14_BalanceTesHaters/issues/4
+    };
+
+    return {
+      comment,
+      screenshotElement: this.selectCommentScreenshotTarget(
+        commentElement,
+        extractedText.sourceElement,
+      ),
     };
   }
 
   private extractCommentText(
     element: HTMLElement,
     authorName?: string,
-  ): string | undefined {
+  ): { text?: string; sourceElement?: HTMLElement } {
     const textElements = new Set<HTMLElement>();
     for (const selector of COMMENT_TEXT_SELECTORS) {
       for (const textElement of this.scrapingSupport.selectAll(
@@ -624,42 +681,104 @@ export class InstagramPostModalScraper {
     }
 
     let selectedText: string | undefined;
+    let selectedTextSourceElement: HTMLElement | undefined;
     for (const textElement of textElements) {
-      if (textElement.closest("a, button, time")) {
-        continue;
-      }
-
-      const text = this.normalizeText(textElement.textContent);
-      if (!text || this.looksLikeUiLabel(text)) {
-        continue;
-      }
-      if (authorName && text === authorName) {
-        continue;
-      }
-      if (!selectedText || text.length > selectedText.length) {
-        selectedText = text;
+      for (const textSegment of this.extractReadableTextSegments(textElement)) {
+        if (authorName && textSegment.text === authorName) {
+          continue;
+        }
+        if (!selectedText || textSegment.text.length > selectedText.length) {
+          selectedText = textSegment.text;
+          selectedTextSourceElement = textSegment.sourceElement;
+        }
       }
     }
 
-    return selectedText;
+    return {
+      text: selectedText,
+      sourceElement: selectedTextSourceElement,
+    };
+  }
+
+  private extractReadableTextSegments(
+    element: HTMLElement,
+  ): Array<{ text: string; sourceElement: HTMLElement }> {
+    const segments: Array<{ text: string; sourceElement: HTMLElement }> = [];
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      const parentElement = node.parentElement;
+      if (!parentElement) {
+        continue;
+      }
+      if (
+        parentElement.closest(
+          "a, button, time, title, svg, [role='button'], [aria-label]",
+        )
+      ) {
+        continue;
+      }
+
+      const text = sanitizeInstagramCommentText(node.textContent);
+      if (!text || looksLikeInstagramUiLabel(text)) {
+        continue;
+      }
+
+      segments.push({
+        text,
+        sourceElement: parentElement,
+      });
+    }
+
+    return segments;
+  }
+
+  private selectCommentScreenshotTarget(
+    commentElement: HTMLElement,
+    textSourceElement?: HTMLElement,
+  ): HTMLElement {
+    if (textSourceElement) {
+      const screenshotContainer = textSourceElement.closest("li, article, div");
+      if (
+        screenshotContainer instanceof HTMLElement &&
+        commentElement.contains(screenshotContainer)
+      ) {
+        return screenshotContainer;
+      }
+      return textSourceElement;
+    }
+
+    return commentElement.closest("li") ?? commentElement;
   }
 
   private scrapAuthorFromContainer(element: HTMLElement): Author | undefined {
-    const channelElement = this.scrapingSupport.select(
+    const channelElements = this.scrapingSupport.selectAll(
       element,
       "a[href^='/']",
       HTMLAnchorElement,
     );
-    const channelElementHref = channelElement?.getAttribute("href");
-    const channelName = this.normalizeText(channelElement?.textContent);
-    if (!channelElement || !channelElementHref || !channelName) {
-      return undefined;
+
+    for (const channelElement of channelElements) {
+      const channelElementHref = channelElement.getAttribute("href");
+      const channelName = normalizeInstagramText(channelElement.textContent);
+      if (!channelElementHref || !channelName) {
+        continue;
+      }
+
+      const accountUrl = new URL(channelElementHref, INSTAGRAM_URL);
+      const pathParts = accountUrl.pathname.split("/").filter(Boolean);
+      if (
+        pathParts.length === 1 &&
+        isLikelyInstagramAccountPath(pathParts[0])
+      ) {
+        return {
+          name: channelName,
+          accountHref: accountUrl.toString(),
+        };
+      }
     }
 
-    return {
-      name: channelName,
-      accountHref: new URL(channelElementHref, INSTAGRAM_URL).toString(),
-    };
+    return undefined;
   }
 
   private scrapPublishedAtFromContainer(
@@ -679,23 +798,6 @@ export class InstagramPostModalScraper {
       type: "absolute",
       date,
     };
-  }
-
-  private normalizeText(text: string | null | undefined): string | undefined {
-    const normalized = text?.trim();
-    if (!normalized) {
-      return undefined;
-    }
-    return normalized;
-  }
-
-  private looksLikeUiLabel(text: string): boolean {
-    const normalizedText = text.toLowerCase();
-    if (/^\d+[.,]?\d*[km]?$/i.test(normalizedText)) {
-      return true;
-    }
-
-    return UI_LABELS.has(normalizedText);
   }
 
   private countAllComments(comments: CommentSnapshot[]): number {

--- a/browser-extension/src/entrypoints/instagram.content/instagram-post-native-scraper.ts
+++ b/browser-extension/src/entrypoints/instagram.content/instagram-post-native-scraper.ts
@@ -6,12 +6,25 @@ import { Author } from "@/shared/model/Author";
 import { INSTAGRAM_URL, instagramPageInfo } from "./instagramPageInfo";
 import { SocialNetwork } from "@/shared/model/SocialNetworkName";
 import { InstagramPostModalScraper } from "./instagram-post-modal-scraper";
+import { ProgressManager } from "@/shared/scraping-content-script/ProgressManager";
+import { captureInstagramCommentScreenshots } from "./instagram-comment-screenshot-capture";
+import {
+  isLikelyInstagramAccountPath,
+  normalizeInstagramText,
+  sanitizeInstagramCommentText,
+} from "./instagram-comment-text-utils";
 
 const LOG_PREFIX = "[CS - InstagramPostNativeScraper] ";
 
 type InstagramPostElements = {
   channelHeader: HTMLElement;
   scrollableArea: HTMLElement;
+};
+
+type ScrapedComments = {
+  comments: CommentSnapshot[];
+  commentElementsById: Map<string, HTMLElement>;
+  usedDatetimeFallback: boolean;
 };
 
 /**
@@ -29,12 +42,14 @@ export class InstagramPostNativeScraper {
     console.debug(LOG_PREFIX, ...data);
   }
 
-  async scrapPost(): Promise<PostSnapshot> {
+  async scrapPost(progressManager: ProgressManager): Promise<PostSnapshot> {
     this.debug("Start Scraping... ", document.URL);
 
     if (this.isModalContext()) {
       this.debug("Modal context detected, routing to modal scraper");
-      return new InstagramPostModalScraper(this.scrapingSupport).scrapPost();
+      return new InstagramPostModalScraper(this.scrapingSupport).scrapPost(
+        progressManager,
+      );
     }
 
     const url = document.URL;
@@ -59,9 +74,33 @@ export class InstagramPostNativeScraper {
     this.debug(`publishedAt: ${JSON.stringify(publishedAt)}`);
 
     this.debug("Scraping comments...");
-    const comments: CommentSnapshot[] = await this.scrapPostComments(
+    const {
+      comments: rawComments,
+      commentElementsById,
+      usedDatetimeFallback,
+    } = await this.scrapPostComments(
       postElements.scrollableArea,
+      progressManager.subTaskProgressManager({ from: 0, to: 70 }),
     );
+
+    const comments = usedDatetimeFallback
+      ? rawComments.filter(
+          (comment) => !this.isPostMetadataEntry(comment, author, publishedAt),
+        )
+      : rawComments;
+
+    this.debug("Capturing comment screenshots...");
+    await captureInstagramCommentScreenshots({
+      comments,
+      commentElementsById,
+      scrapingSupport: this.scrapingSupport,
+      progressManager: progressManager.subTaskProgressManager({
+        from: 70,
+        to: 100,
+      }),
+      debug: this.debug.bind(this),
+    });
+
     this.debug(`${comments.length} comments`);
 
     return {
@@ -75,6 +114,23 @@ export class InstagramPostNativeScraper {
       socialNetwork: SocialNetwork.Instagram,
       textContent,
     };
+  }
+
+  private isPostMetadataEntry(
+    comment: CommentSnapshot,
+    postAuthor: Author,
+    postPublishedAt: PublicationDate,
+  ): boolean {
+    if (
+      postPublishedAt.type !== "absolute" ||
+      comment.publishedAt.type !== "absolute"
+    ) {
+      return false;
+    }
+    return (
+      comment.author.accountHref === postAuthor.accountHref &&
+      comment.publishedAt.date === postPublishedAt.date
+    );
   }
 
   private isModalContext(): boolean {
@@ -141,7 +197,7 @@ export class InstagramPostNativeScraper {
         selector,
         HTMLElement,
       );
-      const text = this.normalizeText(textContentElement?.textContent);
+      const text = normalizeInstagramText(textContentElement?.textContent);
       if (text) {
         return text;
       }
@@ -151,14 +207,6 @@ export class InstagramPostNativeScraper {
     // the whole scraping job.
     this.debug("Post text content not found with known selectors");
     return undefined;
-  }
-
-  private normalizeText(text: string | null | undefined): string | undefined {
-    const normalized = text?.trim();
-    if (!normalized) {
-      return undefined;
-    }
-    return normalized;
   }
 
   private scrapPostPublishedAt(element: HTMLElement): PublicationDate {
@@ -175,20 +223,40 @@ export class InstagramPostNativeScraper {
 
   private async scrapPostComments(
     element: HTMLElement,
-  ): Promise<CommentSnapshot[]> {
+    progressManager: ProgressManager,
+  ): Promise<ScrapedComments> {
     const commentsContainer = this.selectCommentsContainer(element);
     commentsContainer.scrollIntoView();
+    progressManager.setProgress(5);
 
     this.debug("Loading all comment threads...");
     await this.loadAllTopLevelComments(commentsContainer);
+    progressManager.setProgress(50);
 
     this.debug("Expanding all replies...");
     await this.loadAllReplies(commentsContainer);
+    progressManager.setProgress(75);
 
-    const comments = this.scrapCommentThreads(commentsContainer);
+    const commentElementsById = new Map<string, HTMLElement>();
+    let comments = this.scrapCommentThreads(
+      commentsContainer,
+      commentElementsById,
+    );
+    let usedDatetimeFallback = false;
+    if (comments.length === 0) {
+      this.debug(
+        "No comments parsed with native thread selectors, retrying with datetime-marker fallback",
+      );
+      comments = this.scrapCommentsFromDatetimeMarkers(
+        element,
+        commentElementsById,
+      );
+      usedDatetimeFallback = true;
+    }
     this.debug("Comments metadata:", comments);
+    progressManager.setProgress(100);
 
-    return comments;
+    return { comments, commentElementsById, usedDatetimeFallback };
   }
 
   private selectCommentsContainer(element: HTMLElement): HTMLElement {
@@ -304,6 +372,7 @@ export class InstagramPostNativeScraper {
 
   private scrapCommentThreads(
     commentsContainer: HTMLElement,
+    commentElementsById: Map<string, HTMLElement>,
   ): CommentSnapshot[] {
     const commentThreads: CommentThread[] = [];
     const commentThreadContainers = this.scrapingSupport.selectAll(
@@ -313,7 +382,9 @@ export class InstagramPostNativeScraper {
     );
 
     for (const commentThread of commentThreadContainers) {
-      commentThreads.push(this.scrapCommentThread(commentThread));
+      commentThreads.push(
+        this.scrapCommentThread(commentThread, commentElementsById),
+      );
     }
 
     return commentThreads
@@ -321,7 +392,10 @@ export class InstagramPostNativeScraper {
       .map((thread) => thread.comment);
   }
 
-  private scrapCommentThread(commentElement: HTMLElement): CommentThread {
+  private scrapCommentThread(
+    commentElement: HTMLElement,
+    commentElementsById: Map<string, HTMLElement>,
+  ): CommentThread {
     const commentThreadContentElement = this.scrapingSupport.selectOrThrow(
       commentElement,
       ":scope>div",
@@ -330,6 +404,7 @@ export class InstagramPostNativeScraper {
 
     const commentThread = this.scrapCommentThreadContent(
       commentThreadContentElement,
+      commentElementsById,
     );
 
     if (commentThread.scrapingStatus === "failure") {
@@ -343,8 +418,10 @@ export class InstagramPostNativeScraper {
     );
 
     if (repliesContainer) {
-      commentThread.comment.replies =
-        this.scrapCommentReplies(repliesContainer);
+      commentThread.comment.replies = this.scrapCommentReplies(
+        repliesContainer,
+        commentElementsById,
+      );
     }
 
     return commentThread;
@@ -352,6 +429,7 @@ export class InstagramPostNativeScraper {
 
   private scrapCommentReplies(
     repliesContainer: HTMLElement,
+    commentElementsById: Map<string, HTMLElement>,
   ): CommentSnapshot[] {
     const replies: CommentThread[] = [];
     const repliesElements = this.scrapingSupport.selectAll(
@@ -361,7 +439,7 @@ export class InstagramPostNativeScraper {
     );
 
     for (const reply of repliesElements) {
-      replies.push(this.scrapCommentThreadContent(reply));
+      replies.push(this.scrapCommentThreadContent(reply, commentElementsById));
     }
 
     return replies
@@ -371,6 +449,7 @@ export class InstagramPostNativeScraper {
 
   private scrapCommentThreadContent(
     commentThreadContentElement: HTMLElement,
+    commentElementsById: Map<string, HTMLElement>,
   ): CommentThread {
     const baseElement = this.scrapingSupport.select(
       commentThreadContentElement,
@@ -399,20 +478,34 @@ export class InstagramPostNativeScraper {
       };
     }
 
-    const postContent = this.scrapingSupport.select(
-      baseElement,
-      ":scope>div>div:nth-of-type(2)>span",
-      HTMLElement,
-    );
-    const postContentText = this.normalizeText(postContent?.textContent);
-    if (!postContentText) {
+    const author = this.scrapCommentAuthor(baseElement);
+    if (!author) {
+      return {
+        scrapingStatus: "failure",
+        message: "Missing comment author",
+      };
+    }
+
+    const publishedAt = this.scrapCommentPublishedAt(baseElement);
+    if (!publishedAt) {
+      return {
+        scrapingStatus: "failure",
+        message: "Missing comment date",
+      };
+    }
+
+    const extractedText = this.extractCommentText(baseElement, author.name);
+    if (!extractedText.text) {
       return {
         scrapingStatus: "failure",
         message: "Scraping comments without text is not supported yet",
       };
     }
 
-    const comment = this.scrapComment(baseElement, postContentText);
+    const comment = this.buildComment(author, publishedAt, extractedText.text);
+    const screenshotTarget =
+      extractedText.sourceElement?.parentElement ?? extractedText.sourceElement;
+    commentElementsById.set(comment.id, screenshotTarget ?? baseElement);
 
     return {
       scrapingStatus: "success",
@@ -420,30 +513,233 @@ export class InstagramPostNativeScraper {
     };
   }
 
-  private scrapComment(
-    baseElement: HTMLElement,
-    postContentText: string,
-  ): CommentSnapshot {
-    const channelHeader = this.scrapingSupport.selectOrThrow(
-      baseElement,
-      ":scope>div>div",
+  private scrapCommentsFromDatetimeMarkers(
+    root: HTMLElement,
+    commentElementsById: Map<string, HTMLElement>,
+  ): CommentSnapshot[] {
+    const comments: CommentSnapshot[] = [];
+    const seenNode = new Set<HTMLElement>();
+    const seenSignature = new Set<string>();
+    const timeElements = this.scrapingSupport.selectAll(
+      root,
+      "time[datetime]",
       HTMLElement,
     );
 
-    const author = this.scrapPostAuthor(channelHeader);
-    const scrapedAt = currentIsoDate();
-    const publishedAt = this.scrapPostPublishedAt(channelHeader);
+    for (const timeElement of timeElements) {
+      const closestListItem = timeElement.closest("li");
+      const commentElement =
+        (closestListItem instanceof HTMLElement
+          ? closestListItem
+          : undefined) ??
+        this.findCommentElementFromTime(timeElement) ??
+        timeElement.parentElement;
+      if (!commentElement || seenNode.has(commentElement)) {
+        continue;
+      }
 
+      const author = this.scrapCommentAuthor(commentElement);
+      const publishedAt = this.scrapCommentPublishedAt(commentElement);
+      const extractedText = this.extractCommentText(
+        commentElement,
+        author?.name,
+      );
+      if (
+        !author ||
+        !publishedAt ||
+        publishedAt.type !== "absolute" ||
+        !extractedText.text
+      ) {
+        continue;
+      }
+
+      const signature = [
+        author.accountHref,
+        publishedAt.date,
+        extractedText.text,
+      ].join("|");
+      if (seenSignature.has(signature)) {
+        continue;
+      }
+      seenNode.add(commentElement);
+      seenSignature.add(signature);
+
+      const comment = this.buildComment(
+        author,
+        publishedAt,
+        extractedText.text,
+      );
+      const closestScreenshotContainer =
+        extractedText.sourceElement?.closest("li, article, div") ?? undefined;
+      const screenshotTarget =
+        (closestScreenshotContainer instanceof HTMLElement
+          ? closestScreenshotContainer
+          : undefined) ??
+        extractedText.sourceElement ??
+        commentElement;
+      commentElementsById.set(comment.id, screenshotTarget);
+      comments.push(comment);
+    }
+
+    return comments;
+  }
+
+  private findCommentElementFromTime(
+    timeElement: HTMLElement,
+  ): HTMLElement | undefined {
+    let current: HTMLElement | null = timeElement;
+
+    for (let depth = 0; depth < 8 && current; depth += 1) {
+      if (this.isLikelyCommentElement(current)) {
+        return current;
+      }
+      current = current.parentElement;
+    }
+    return undefined;
+  }
+
+  private isLikelyCommentElement(element: HTMLElement): boolean {
+    const author = this.scrapCommentAuthor(element);
+    const publishedAt = this.scrapCommentPublishedAt(element);
+    const text = this.extractCommentText(element, author?.name).text;
+    if (!author || !publishedAt || publishedAt.type !== "absolute" || !text) {
+      return false;
+    }
+
+    const timeCount = this.scrapingSupport.selectAll(
+      element,
+      "time[datetime]",
+      HTMLElement,
+    ).length;
+    return timeCount <= 4;
+  }
+
+  private buildComment(
+    author: Author,
+    publishedAt: PublicationDate,
+    textContent: string,
+  ): CommentSnapshot {
     return {
       id: crypto.randomUUID(),
       author,
-      textContent: postContentText,
-      publishedAt: publishedAt,
-      // TODO Crop a screenshot of the whole page. HTMLElement doesn't have a screenshot method such as Puppeteer.
+      textContent,
+      publishedAt,
+      // Filled later during screenshot capture phase.
       screenshotData: "",
-      scrapedAt,
+      scrapedAt: currentIsoDate(),
       replies: [],
       nbLikes: 0, // See https://github.com/dataforgoodfr/14_BalanceTesHaters/issues/4
     };
+  }
+
+  private scrapCommentAuthor(baseElement: HTMLElement): Author | undefined {
+    const linkCandidates = this.scrapingSupport.selectAll(
+      baseElement,
+      "a[href^='/']",
+      HTMLAnchorElement,
+    );
+
+    for (const candidate of linkCandidates) {
+      const href = candidate.getAttribute("href");
+      const name = normalizeInstagramText(candidate.textContent);
+      if (!href || !name) {
+        continue;
+      }
+
+      const accountUrl = new URL(href, INSTAGRAM_URL);
+      const pathParts = accountUrl.pathname.split("/").filter(Boolean);
+      if (
+        pathParts.length === 1 &&
+        isLikelyInstagramAccountPath(pathParts[0])
+      ) {
+        return {
+          name,
+          accountHref: accountUrl.toString(),
+        };
+      }
+    }
+
+    return undefined;
+  }
+
+  private scrapCommentPublishedAt(
+    baseElement: HTMLElement,
+  ): PublicationDate | undefined {
+    const timeElement = this.scrapingSupport.select(
+      baseElement,
+      "time[datetime], time",
+      HTMLElement,
+    );
+    const date = timeElement?.getAttribute("datetime");
+    if (!date) {
+      return undefined;
+    }
+    return {
+      type: "absolute",
+      date,
+    };
+  }
+
+  private extractCommentText(
+    baseElement: HTMLElement,
+    authorName?: string,
+  ): { text?: string; sourceElement?: HTMLElement } {
+    const textCandidates = this.scrapingSupport.selectAll(
+      baseElement,
+      ":scope>div>div:nth-of-type(2)>span, :scope span[dir='auto'], :scope div[dir='auto'] span",
+      HTMLElement,
+    );
+    let bestText: string | undefined;
+    let bestSource: HTMLElement | undefined;
+
+    for (const candidate of textCandidates) {
+      for (const textSegment of this.extractReadableTextSegments(candidate)) {
+        if (authorName && textSegment.text === authorName) {
+          continue;
+        }
+        if (!bestText || textSegment.text.length > bestText.length) {
+          bestText = textSegment.text;
+          bestSource = textSegment.sourceElement;
+        }
+      }
+    }
+
+    return {
+      text: bestText,
+      sourceElement: bestSource,
+    };
+  }
+
+  private extractReadableTextSegments(
+    element: HTMLElement,
+  ): Array<{ text: string; sourceElement: HTMLElement }> {
+    const segments: Array<{ text: string; sourceElement: HTMLElement }> = [];
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT);
+
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      const parentElement = node.parentElement;
+      if (!parentElement) {
+        continue;
+      }
+      if (
+        parentElement.closest(
+          "a, button, time, title, svg, [role='button'], [aria-label]",
+        )
+      ) {
+        continue;
+      }
+
+      const text = sanitizeInstagramCommentText(node.textContent);
+      if (!text) {
+        continue;
+      }
+
+      segments.push({
+        text,
+        sourceElement: parentElement,
+      });
+    }
+
+    return segments;
   }
 }

--- a/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
@@ -49,6 +49,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useForm } from "@tanstack/react-form";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { buildDataUrl, PNG_MIME_TYPE } from "@/shared/utils/data-url";
 
 /**
  * Merged view of Post Snapshot
@@ -62,11 +69,13 @@ export default function CommentsTable({
   defaultSelectedCommentIdList,
   onSubmit,
   formId,
+  showScreenshotColumn = false,
 }: Readonly<{
   commentList: PostCommentWithId[];
   defaultSelectedCommentIdList: string[];
   onSubmit: (commentIdList: string[]) => void;
   formId: string;
+  showScreenshotColumn?: boolean;
 }>) {
   const [inputValue, setInputValue] = React.useState("");
   const [searchTerm, setSearchTerm] = React.useState("");
@@ -76,6 +85,10 @@ export default function CommentsTable({
   const [selectedCommentIdList, setSelectedCommentIdList] = React.useState<
     Set<string>
   >(new Set(defaultSelectedCommentIdList));
+  const [screenshotDialogOpen, setScreenshotDialogOpen] = React.useState(false);
+  const [selectedScreenshot, setSelectedScreenshot] = React.useState<
+    string | null
+  >(null);
   const form = useForm({
     defaultValues: {
       commentIdList: defaultSelectedCommentIdList,
@@ -99,6 +112,11 @@ export default function CommentsTable({
 
   const toggleCommentSelection = (id: string) => {
     updateSelectedCommentList(addOrRemoveValueToSet(selectedCommentIdList, id));
+  };
+
+  const openScreenshotDialog = (screenshotData: string) => {
+    setSelectedScreenshot(screenshotData);
+    setScreenshotDialogOpen(true);
   };
 
   const filteredComments = React.useMemo(
@@ -164,6 +182,25 @@ export default function CommentsTable({
             {row.original.textContent}
           </div>
         ),
+      },
+      {
+        id: "screenshot",
+        header: "Capture",
+        size: 14,
+        cell: ({ row }) => {
+          if (!row.original.screenshotData) {
+            return <span className="text-muted-foreground">N/A</span>;
+          }
+
+          return (
+            <img
+              src={buildDataUrl(row.original.screenshotData, PNG_MIME_TYPE)}
+              alt="Capture du commentaire"
+              className="max-h-16 cursor-pointer border rounded"
+              onClick={() => openScreenshotDialog(row.original.screenshotData)}
+            />
+          );
+        },
       },
       {
         id: "vue",
@@ -237,12 +274,19 @@ export default function CommentsTable({
     ],
     // Les colonnes seront rafraichies lorsque visibleComments change, pour
     // mettre à jour les icônes d'œil et les classes de floutage
-    [visibleComments, filteredComments, selectedCommentIdList],
+    [
+      filteredComments,
+      openScreenshotDialog,
+      selectedCommentIdList,
+      visibleComments,
+    ],
   );
 
   const table = useReactTable({
     data: filteredComments,
-    columns,
+    columns: columns.filter(
+      (column) => showScreenshotColumn || column.id !== "screenshot",
+    ),
     getCoreRowModel: getCoreRowModel(),
     getRowId: (row) => row.id,
     getPaginationRowModel: getPaginationRowModel(),
@@ -277,132 +321,151 @@ export default function CommentsTable({
   };
 
   return (
-    <form
-      id={formId}
-      className="rounded-md border mt-2"
-      onSubmit={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        void form.handleSubmit();
-      }}
-    >
-      <div className="p-3 flex justify-between">
-        <InputGroup className="mx-4 w-1/3">
-          <InputGroupInput
-            value={inputValue}
-            onChange={(event) => setInputValue(event.target.value)}
-            placeholder="Rechercher"
-          />
-          <InputGroupAddon>
-            <SearchIcon />
-          </InputGroupAddon>
-        </InputGroup>
-        <div className="flex gap-4">
-          <Button variant="outline" disabled>
-            Tout sélectionner
-          </Button>
-          <Button variant="outline" disabled>
-            Filtrer <Funnel />
-          </Button>
-          <Button variant="outline" disabled>
-            Trier <ArrowDownUp />
-          </Button>{" "}
-        </div>
-      </div>
-      <form.Field
-        name="commentIdList"
-        validators={{
-          onChange: ({ value }) =>
-            value.length < 1
-              ? "Sélectionner au moins un commentaire"
-              : undefined,
+    <>
+      <form
+        id={formId}
+        className="rounded-md border mt-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          void form.handleSubmit();
         }}
       >
-        {(field) => (
-          <>
-            {field.state.meta.errors.length > 0 && (
-              <div className="text-destructive text-center text-sm mb-2">
-                {field.state.meta.errors.join(", ")}
-              </div>
-            )}
-            <Table className="w-full table-fixed">
-              <TableHeader className="bg-gray-200">
-                {table.getHeaderGroups().map((headerGroup) => (
-                  <TableRow key={headerGroup.id}>
-                    {headerGroup.headers.map((header) => (
-                      <TableHead
-                        key={header.id}
-                        style={{ width: `${header.column.columnDef.size}%` }}
-                      >
-                        {header.isPlaceholder
-                          ? null
-                          : flexRender(
-                              header.column.columnDef.header,
-                              header.getContext(),
-                            )}
-                      </TableHead>
-                    ))}
-                  </TableRow>
-                ))}
-              </TableHeader>
-              <TableBody>
-                {table.getRowModel().rows.map((row) => (
-                  <TableRow key={row.id}>
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell key={cell.id}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </>
-        )}
-      </form.Field>
-      <div className="flex items-center justify-between gap-4 p-6 mt-3 mb-6">
-        <Field orientation="horizontal" className="w-fit">
-          <FieldLabel htmlFor="select-rows-per-page">
-            Nombre de commentaires par page
-          </FieldLabel>
-          <Select
-            defaultValue={table.getState().pagination.pageSize}
-            onValueChange={(e) => {
-              table.setPageSize(Number(e));
-            }}
-          >
-            <SelectTrigger className="w-20" id="select-rows-per-page">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent align="start">
-              <SelectGroup>
-                <SelectItem value="10">10</SelectItem>
-                <SelectItem value="25">25</SelectItem>
-                <SelectItem value="50">50</SelectItem>
-                <SelectItem value="100">100</SelectItem>
-              </SelectGroup>
-            </SelectContent>
-          </Select>
-        </Field>
-        <Pagination className="mx-0 w-auto">
-          <PaginationContent>
-            {table.getCanPreviousPage() && (
-              <PaginationItem>
-                <PaginationPrevious onClick={() => table.previousPage()} />
-              </PaginationItem>
-            )}
-            {table.getCanNextPage() && (
-              <PaginationItem>
-                <PaginationNext onClick={() => table.nextPage()} />
-              </PaginationItem>
-            )}
-          </PaginationContent>
-        </Pagination>
-      </div>
-    </form>
+        <div className="p-3 flex justify-between">
+          <InputGroup className="mx-4 w-1/3">
+            <InputGroupInput
+              value={inputValue}
+              onChange={(event) => setInputValue(event.target.value)}
+              placeholder="Rechercher"
+            />
+            <InputGroupAddon>
+              <SearchIcon />
+            </InputGroupAddon>
+          </InputGroup>
+          <div className="flex gap-4">
+            <Button variant="outline" disabled>
+              Tout sélectionner
+            </Button>
+            <Button variant="outline" disabled>
+              Filtrer <Funnel />
+            </Button>
+            <Button variant="outline" disabled>
+              Trier <ArrowDownUp />
+            </Button>{" "}
+          </div>
+        </div>
+        <form.Field
+          name="commentIdList"
+          validators={{
+            onChange: ({ value }) =>
+              value.length < 1
+                ? "Sélectionner au moins un commentaire"
+                : undefined,
+          }}
+        >
+          {(field) => (
+            <>
+              {field.state.meta.errors.length > 0 && (
+                <div className="text-destructive text-center text-sm mb-2">
+                  {field.state.meta.errors.join(", ")}
+                </div>
+              )}
+              <Table className="w-full table-fixed">
+                <TableHeader className="bg-gray-200">
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <TableRow key={headerGroup.id}>
+                      {headerGroup.headers.map((header) => (
+                        <TableHead
+                          key={header.id}
+                          style={{ width: `${header.column.columnDef.size}%` }}
+                        >
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext(),
+                              )}
+                        </TableHead>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableHeader>
+                <TableBody>
+                  {table.getRowModel().rows.map((row) => (
+                    <TableRow key={row.id}>
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </>
+          )}
+        </form.Field>
+        <div className="flex items-center justify-between gap-4 p-6 mt-3 mb-6">
+          <Field orientation="horizontal" className="w-fit">
+            <FieldLabel htmlFor="select-rows-per-page">
+              Nombre de commentaires par page
+            </FieldLabel>
+            <Select
+              defaultValue={table.getState().pagination.pageSize}
+              onValueChange={(e) => {
+                table.setPageSize(Number(e));
+              }}
+            >
+              <SelectTrigger className="w-20" id="select-rows-per-page">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent align="start">
+                <SelectGroup>
+                  <SelectItem value="10">10</SelectItem>
+                  <SelectItem value="25">25</SelectItem>
+                  <SelectItem value="50">50</SelectItem>
+                  <SelectItem value="100">100</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </Field>
+          <Pagination className="mx-0 w-auto">
+            <PaginationContent>
+              {table.getCanPreviousPage() && (
+                <PaginationItem>
+                  <PaginationPrevious onClick={() => table.previousPage()} />
+                </PaginationItem>
+              )}
+              {table.getCanNextPage() && (
+                <PaginationItem>
+                  <PaginationNext onClick={() => table.nextPage()} />
+                </PaginationItem>
+              )}
+            </PaginationContent>
+          </Pagination>
+        </div>
+      </form>
+      <Dialog
+        open={screenshotDialogOpen}
+        onOpenChange={setScreenshotDialogOpen}
+      >
+        <DialogContent className="max-w-fit">
+          <DialogHeader>
+            <DialogTitle>Capture du commentaire</DialogTitle>
+          </DialogHeader>
+          {selectedScreenshot ? (
+            <img
+              src={buildDataUrl(selectedScreenshot, PNG_MIME_TYPE)}
+              alt="Capture du commentaire"
+              className="max-h-[75vh]"
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/browser-extension/src/entrypoints/posts/Report/Step3Comments.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Step3Comments.tsx
@@ -61,6 +61,7 @@ function Step3Comments({
           }
           onSubmit={handleSubmit}
           formId={getFormId(stepper.state.current.data.id)}
+          showScreenshotColumn={true}
         />
       )}
     </div>

--- a/browser-extension/src/shared/model/post/Post.ts
+++ b/browser-extension/src/shared/model/post/Post.ts
@@ -19,6 +19,11 @@ export type Post = PostSharedProperties & {
 
 export type PostComment = CommentSharedProperties & {
   /**
+   * Base64 encoded PNG screenshot captured at scrape time.
+   */
+  screenshotData: string;
+
+  /**
    * True if comment was added in latest snapshot of post and more than one snapshot existed
    */
   isNew: boolean;

--- a/browser-extension/src/shared/model/post/__tests__/buildCommentsFromSnapshots.test.ts
+++ b/browser-extension/src/shared/model/post/__tests__/buildCommentsFromSnapshots.test.ts
@@ -416,6 +416,54 @@ describe("buildCommentsFromSnapshots", () => {
       expect(result[1].isDeleted).toBe(false);
     });
   });
+
+  describe("screenshot selection", () => {
+    it("should keep the latest screenshot when latest snapshot has one", () => {
+      const commentV1 = createCommentSnapshot({
+        commentId: "screenshot-latest",
+        textContent: "Same text",
+        screenshotData: "b2xkLXNjcmVlbnNob3Q=", // old-screenshot
+        scrapedAt: "2024-01-01T00:01:00.000Z",
+      });
+      const commentV2 = createCommentSnapshot({
+        commentId: "screenshot-latest",
+        textContent: "Same text",
+        screenshotData: "bmV3LXNjcmVlbnNob3Q=", // new-screenshot
+        scrapedAt: "2024-01-01T00:02:00.000Z",
+      });
+
+      const result = buildCommentsFromSnapshots([
+        createMinimalPostSnapshot([commentV1]),
+        createMinimalPostSnapshot([commentV2]),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].screenshotData).toBe("bmV3LXNjcmVlbnNob3Q=");
+    });
+
+    it("should fallback to latest non-empty screenshot when latest is empty", () => {
+      const commentV1 = createCommentSnapshot({
+        commentId: "screenshot-fallback",
+        textContent: "Same text",
+        screenshotData: "dmFsaWQtc2NyZWVuc2hvdA==", // valid-screenshot
+        scrapedAt: "2024-01-01T00:01:00.000Z",
+      });
+      const commentV2 = createCommentSnapshot({
+        commentId: "screenshot-fallback",
+        textContent: "Same text",
+        screenshotData: "",
+        scrapedAt: "2024-01-01T00:02:00.000Z",
+      });
+
+      const result = buildCommentsFromSnapshots([
+        createMinimalPostSnapshot([commentV1]),
+        createMinimalPostSnapshot([commentV2]),
+      ]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].screenshotData).toBe("dmFsaWQtc2NyZWVuc2hvdA==");
+    });
+  });
 });
 
 function createMinimalPostSnapshot(comments: CommentSnapshot[]): PostSnapshot {

--- a/browser-extension/src/shared/model/post/buildCommentsFromSnapshots.ts
+++ b/browser-extension/src/shared/model/post/buildCommentsFromSnapshots.ts
@@ -117,11 +117,27 @@ function buildPostCommentForGroupOfSameText(
     textContent: groupOldestComment.commentSnapshot.textContent,
     publishedAt: groupOldestComment.commentSnapshot.publishedAt,
     author: groupOldestComment.commentSnapshot.author,
+    screenshotData: selectScreenshotData(sortedByScrapedAt),
     classification: groupOldestComment.commentSnapshot.classification,
     classifiedAt: groupOldestComment.commentSnapshot.classifiedAt,
     isNew: postSnapshotsCount > 1 && isGroupOldestCommentFromLatestSnapshot,
     isDeleted: !isGroupLatestCommentFromLatestSnapshot,
   };
+}
+
+function selectScreenshotData(
+  sortedByScrapedAt: CommentSnapshotWithPostInfo[],
+): string {
+  const latest = sortedByScrapedAt[sortedByScrapedAt.length - 1];
+  if (latest.commentSnapshot.screenshotData) {
+    return latest.commentSnapshot.screenshotData;
+  }
+
+  const latestNonEmpty = [...sortedByScrapedAt]
+    .reverse()
+    .find((item) => item.commentSnapshot.screenshotData);
+
+  return latestNonEmpty?.commentSnapshot.screenshotData ?? "";
 }
 
 function commentId(comment: CommentSnapshot): string {


### PR DESCRIPTION
## Contexte
Cette PR implémente l'issue #108 : capturer les screenshots des commentaires Instagram pendant le scraping (mode page + modal) et les exposer dans l'étape 3 du rapport.

Closes #108

## Changements principaux
### Scraping Instagram
- Ajout d'une capture **best-effort** des screenshots de commentaires (aucun échec bloquant si une capture échoue).
- Support de la capture en **mode page** et **mode modal**.
- Passage du `ProgressManager` dans les scrapers Instagram pour refléter les phases de chargement/capture.
- Amélioration de la robustesse du parsing commentaire (auteur/texte/date) et fallback natif par `time[datetime]`.
- Filtrage explicite de la métadonnée du post dans le fallback natif pour éviter de l'interpréter comme commentaire.

### Modèle et agrégation
- Ajout de `screenshotData` dans `PostComment`.
- `buildCommentsFromSnapshots` conserve le screenshot le plus récent disponible (fallback sur le dernier non vide).

### UI Rapport (Step 3)
- `CommentsTable` supporte un mode d'affichage des screenshots.
- Activation de ce mode dans `Report/Step3Comments`.
- Ajout d'une miniature cliquable avec aperçu agrandi, et fallback visuel `N/A` si absent.

## Screenshot
<img width="1778" height="1183" alt="image" src="https://github.com/user-attachments/assets/146e784d-6cd6-4dfd-b3a9-a66d1844e4f7" />
