### PR TITLE
fix: scraping Instagram reels (#84)

### DIFF
--- a/browser-extension/src/entrypoints/instagram.content/__tests__/instagramPageInfo.test.ts
+++ b/browser-extension/src/entrypoints/instagram.content/__tests__/instagramPageInfo.test.ts
@@ -3,12 +3,12 @@ import { instagramPageInfo } from "../instagramPageInfo";
 
 describe("instagramPageInfo", () => {
   it("returns scrapable info for /p/<id>", () => {
-    expect(instagramPageInfo("https://www.instagram.com/p/ABC123/")).toMatchObject(
-      {
-        isScrapablePost: true,
-        postId: "ABC123",
-      },
-    );
+    expect(
+      instagramPageInfo("https://www.instagram.com/p/ABC123/"),
+    ).toMatchObject({
+      isScrapablePost: true,
+      postId: "ABC123",
+    });
   });
 
   it("returns scrapable info for /reel/<id>", () => {

--- a/browser-extension/src/entrypoints/instagram.content/__tests__/instagramPageInfo.test.ts
+++ b/browser-extension/src/entrypoints/instagram.content/__tests__/instagramPageInfo.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { instagramPageInfo } from "../instagramPageInfo";
+
+describe("instagramPageInfo", () => {
+  it("returns scrapable info for /p/<id>", () => {
+    expect(instagramPageInfo("https://www.instagram.com/p/ABC123/")).toMatchObject(
+      {
+        isScrapablePost: true,
+        postId: "ABC123",
+      },
+    );
+  });
+
+  it("returns scrapable info for /reel/<id>", () => {
+    expect(
+      instagramPageInfo("https://www.instagram.com/reel/DW6WIBXDQhN/"),
+    ).toMatchObject({
+      isScrapablePost: true,
+      postId: "DW6WIBXDQhN",
+    });
+  });
+
+  it("returns scrapable info for /reels/<id>", () => {
+    expect(
+      instagramPageInfo("https://www.instagram.com/reels/DW6WIBXDQhN/"),
+    ).toMatchObject({
+      isScrapablePost: true,
+      postId: "DW6WIBXDQhN",
+    });
+  });
+
+  it("returns not scrapable for non post/reel routes", () => {
+    expect(instagramPageInfo("https://www.instagram.com/explore/")).toEqual({
+      isScrapablePost: false,
+    });
+  });
+
+  it("returns not scrapable for /reels/ listing route without id", () => {
+    expect(instagramPageInfo("https://www.instagram.com/reels/")).toEqual({
+      isScrapablePost: false,
+    });
+  });
+
+  it("returns not scrapable for /reels/audio/<id> route", () => {
+    expect(
+      instagramPageInfo(
+        "https://www.instagram.com/reels/audio/26246882584981015/",
+      ),
+    ).toEqual({
+      isScrapablePost: false,
+    });
+  });
+});

--- a/browser-extension/src/entrypoints/instagram.content/instagram-post-modal-scraper.ts
+++ b/browser-extension/src/entrypoints/instagram.content/instagram-post-modal-scraper.ts
@@ -250,7 +250,10 @@ export class InstagramPostModalScraper {
 
     return {
       name: channelName,
-      accountHref: new URL(`/${selectedAccountPath}/`, INSTAGRAM_URL).toString(),
+      accountHref: new URL(
+        `/${selectedAccountPath}/`,
+        INSTAGRAM_URL,
+      ).toString(),
     };
   }
 

--- a/browser-extension/src/entrypoints/instagram.content/instagram-post-modal-scraper.ts
+++ b/browser-extension/src/entrypoints/instagram.content/instagram-post-modal-scraper.ts
@@ -36,11 +36,23 @@ const LOAD_MORE_COMMENTS_LABELS = [
   "afficher plus de commentaires",
   "afficher tous les commentaires",
   "charger d'autres commentaires",
+  "voir les commentaires masques",
+  "voir le commentaire masque",
+  "afficher les commentaires masques",
+  "afficher le commentaire masque",
+  "voir ce commentaire",
+  "voir ce message",
   "show more comments",
   "show all comments",
   "load more comments",
   "view more comments",
   "view all comments",
+  "view hidden comments",
+  "see hidden comments",
+  "show hidden comments",
+  "show hidden comment",
+  "show this comment",
+  "see this comment",
   "more comments",
   "plus de commentaires",
 ];
@@ -152,63 +164,109 @@ export class InstagramPostModalScraper {
 
   private selectPostElements(): InstagramPostElements {
     const modalRoot = this.selectModalRoot();
-    const authorLink = this.scrapingSupport.select(
-      modalRoot,
-      "header a[href^='/'], a[href^='/']",
-      HTMLAnchorElement,
-    );
-
-    const channelHeader =
-      authorLink?.closest("header") ?? authorLink?.parentElement ?? modalRoot;
 
     return {
-      channelHeader,
+      channelHeader: modalRoot,
       // In modal layouts comments and metadata are usually inside the same article.
       scrollableArea: modalRoot,
     };
   }
 
   private selectModalRoot(): HTMLElement {
-    const candidates = this.scrapingSupport.selectAll(
-      document,
-      '[role="dialog"] article, main article',
-      HTMLElement,
-    );
-    for (const candidate of candidates) {
-      if (
-        this.scrapingSupport.select(
-          candidate,
-          "a[href^='/'], time[datetime]",
-          HTMLElement,
-        )
-      ) {
-        return candidate;
+    const selectors = [
+      '[role="dialog"] article',
+      '[role="dialog"]',
+      "main article",
+    ];
+    const candidates: HTMLElement[] = [];
+    for (const selector of selectors) {
+      for (const candidate of this.scrapingSupport.selectAll(
+        document,
+        selector,
+        HTMLElement,
+      )) {
+        candidates.push(candidate);
       }
     }
 
+    let firstWithDateTime: HTMLElement | undefined;
+    for (const candidate of candidates) {
+      const hasAuthorLink = this.scrapingSupport.select(
+        candidate,
+        "a[href^='/']",
+        HTMLAnchorElement,
+      );
+      const hasDateTime = this.scrapingSupport.select(
+        candidate,
+        "time[datetime]",
+        HTMLElement,
+      );
+      if (hasAuthorLink && hasDateTime) {
+        return candidate;
+      }
+
+      if (!firstWithDateTime && hasDateTime) {
+        firstWithDateTime = candidate;
+      }
+    }
+
+    if (firstWithDateTime) {
+      return firstWithDateTime;
+    }
     throw new Error("Failed to resolve selector: instagram modal root");
   }
 
   private scrapPostAuthor(channelHeader: HTMLElement): Author {
-    const channelElement = this.scrapingSupport.select(
+    const links = this.scrapingSupport.selectAll(
       channelHeader,
-      ":scope a[href^='/']",
+      "a[href^='/']",
       HTMLAnchorElement,
     );
-    const channelElementHref = channelElement?.getAttribute("href");
-    if (!channelElement || !channelElementHref) {
+
+    let selectedLink: HTMLAnchorElement | undefined;
+    let selectedAccountPath: string | undefined;
+    for (const link of links) {
+      const href = link.getAttribute("href");
+      if (!href) {
+        continue;
+      }
+      const accountPath = this.extractInstagramAccountPathFromHref(href);
+      if (accountPath) {
+        selectedLink = link;
+        selectedAccountPath = accountPath;
+        break;
+      }
+    }
+
+    if (!selectedLink || !selectedAccountPath) {
       throw new Error("Missing channel href");
     }
 
-    const channelName = normalizeInstagramText(channelElement.textContent);
+    const channelName =
+      normalizeInstagramText(selectedLink.textContent) ?? selectedAccountPath;
     if (!channelName) {
       throw new Error("Missing channel name");
     }
 
     return {
       name: channelName,
-      accountHref: new URL(channelElementHref, INSTAGRAM_URL).toString(),
+      accountHref: new URL(`/${selectedAccountPath}/`, INSTAGRAM_URL).toString(),
     };
+  }
+
+  private extractInstagramAccountPathFromHref(
+    href: string,
+  ): string | undefined {
+    const accountUrl = new URL(href, INSTAGRAM_URL);
+    const pathParts = accountUrl.pathname.split("/").filter(Boolean);
+    if (pathParts.length !== 1) {
+      return undefined;
+    }
+    const [path] = pathParts;
+    if (!isLikelyInstagramAccountPath(path)) {
+      return undefined;
+    }
+    return path;
   }
 
   private scrapPostTextContent(element: HTMLElement): string {
@@ -321,12 +379,17 @@ export class InstagramPostModalScraper {
     scrollableArea: HTMLElement,
   ): Promise<void> {
     const dialogRoot = scrollableArea.closest("[role='dialog']");
-    const interactionContainers: HTMLElement[] = [
+    const interactionContainers = new Set<HTMLElement>([
       commentsContainer,
       scrollableArea,
-    ];
+    ]);
+    const scrollableCommentsContainer =
+      this.selectScrollableCommentsContainer(commentsContainer);
+    if (scrollableCommentsContainer) {
+      interactionContainers.add(scrollableCommentsContainer);
+    }
     if (dialogRoot instanceof HTMLElement) {
-      interactionContainers.push(dialogRoot);
+      interactionContainers.add(dialogRoot);
     }
 
     let previousMarkerCount = -1;
@@ -335,8 +398,9 @@ export class InstagramPostModalScraper {
     for (let i = 0; i < 80; i += 1) {
       await this.scrapingSupport.resumeHostPage();
 
-      const clicked = this.clickLoadMoreCommentsControls(interactionContainers);
-      const scrolled = interactionContainers
+      const containers = Array.from(interactionContainers);
+      const clicked = this.clickLoadMoreCommentsControls(containers);
+      const scrolled = containers
         .map((container) => this.scrollToBottom(container))
         .some(Boolean);
       const hasSpinner = Boolean(this.selectSpinner(commentsContainer));
@@ -359,6 +423,28 @@ export class InstagramPostModalScraper {
 
       await this.scrapingSupport.sleep(350);
     }
+  }
+
+  private selectScrollableCommentsContainer(
+    commentsContainer: HTMLElement,
+  ): HTMLElement | undefined {
+    const candidates = [
+      commentsContainer,
+      ...this.scrapingSupport.selectAll(
+        commentsContainer,
+        "div, ul, section",
+        HTMLElement,
+      ),
+    ];
+
+    const scrollables = candidates.filter(
+      (element) => element.scrollHeight > element.clientHeight + 20,
+    );
+    if (scrollables.length === 0) {
+      return undefined;
+    }
+
+    return scrollables.sort((a, b) => b.clientHeight - a.clientHeight)[0];
   }
 
   private selectLoadMoreCommentsButtons(container: HTMLElement): HTMLElement[] {
@@ -387,11 +473,16 @@ export class InstagramPostModalScraper {
       return clickableAncestor;
     }
 
-    if (element instanceof HTMLElement) {
+    if (
+      element instanceof HTMLButtonElement ||
+      element instanceof HTMLAnchorElement ||
+      (element instanceof HTMLElement &&
+        element.getAttribute("role") === "button")
+    ) {
       return element;
     }
 
-    return element.parentElement ?? undefined;
+    return undefined;
   }
 
   private extractControlSearchText(element: Element): string | undefined {
@@ -449,13 +540,45 @@ export class InstagramPostModalScraper {
           continue;
         }
         seen.add(control);
-        control.scrollIntoView();
-        control.click();
+        this.activateControl(control);
         clicked = true;
       }
     }
 
     return clicked;
+  }
+
+  private activateControl(control: HTMLElement): void {
+    control.scrollIntoView({ block: "center", inline: "nearest" });
+    control.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      }),
+    );
+    control.dispatchEvent(
+      new MouseEvent("mouseup", {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      }),
+    );
+    control.click();
+    control.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    control.dispatchEvent(
+      new KeyboardEvent("keyup", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
   }
 
   private scrollToBottom(element: HTMLElement): boolean {

--- a/browser-extension/src/entrypoints/instagram.content/instagram-post-native-scraper.ts
+++ b/browser-extension/src/entrypoints/instagram.content/instagram-post-native-scraper.ts
@@ -163,47 +163,58 @@ export class InstagramPostNativeScraper {
       return true;
     }
 
-    const commentControl = this.selectReelCommentControl();
-    if (!commentControl) {
+    const baselineCommentTimeCount = this.countLikelyCommentTimeMarkers();
+    const commentControls = this.selectReelCommentControls();
+    if (commentControls.length === 0) {
       this.debug("Could not find reel comment control");
       return false;
     }
 
-    this.activateControl(commentControl);
-    await this.scrapingSupport.sleep(300);
-
-    const waitResult = await this.scrapingSupport.waitForSelector(
-      document,
-      '[role="dialog"]',
-      HTMLElement,
-      {
-        timeout: 2500,
-        predicate: (dialogElement) =>
-          Boolean(
-            this.scrapingSupport.select(
-              dialogElement,
-              "time[datetime]",
-              HTMLElement,
-            ),
-          ),
-      },
+    this.debug(
+      `Found ${commentControls.length} reel comment control candidate(s)`,
     );
+    for (const control of commentControls.slice(0, 4)) {
+      const label = this.extractControlSearchText(control);
+      this.debug("Trying reel comment control", label ?? "<no-label>");
+      this.activateControl(control);
+      await this.scrapingSupport.sleep(250);
 
-    if (waitResult.status === "failure") {
-      this.debug(
-        "Reel dialog not detected after comment click; trying inline reel layout",
+      const waitResult = await this.scrapingSupport.waitForSelector(
+        document,
+        '[role="dialog"]',
+        HTMLElement,
+        {
+          timeout: 2000,
+        },
       );
-      return false;
+
+      if (waitResult.status === "success") {
+        this.debug("Reel comments panel opened in dialog");
+        return true;
+      }
+
+      const currentCommentTimeCount = this.countLikelyCommentTimeMarkers();
+      if (currentCommentTimeCount > baselineCommentTimeCount) {
+        this.debug(
+          "Reel comments panel likely opened in inline layout",
+          `time markers ${baselineCommentTimeCount} -> ${currentCommentTimeCount}`,
+        );
+        return true;
+      }
     }
 
-    this.debug("Reel comments panel opened");
-    return true;
+    this.debug(
+      "Reel comments panel not detected after trying all controls",
+      `baseline time markers: ${baselineCommentTimeCount}`,
+    );
+    return false;
   }
 
-  private selectReelCommentControl(): HTMLElement | undefined {
+  private selectReelCommentControls(): HTMLElement[] {
     const elements = Array.from(
       document.querySelectorAll(REEL_COMMENT_CONTROL_SELECTOR),
     );
+    const controls = new Set<HTMLElement>();
 
     for (const element of elements) {
       const text = this.extractControlSearchText(element);
@@ -218,11 +229,19 @@ export class InstagramPostNativeScraper {
       }
       const target = this.resolveClickableControl(element);
       if (target) {
-        return target;
+        controls.add(target);
       }
     }
 
-    return undefined;
+    return Array.from(controls);
+  }
+
+  private countLikelyCommentTimeMarkers(): number {
+    return this.scrapingSupport.selectAll(
+      document,
+      "main li time[datetime], [role='dialog'] time[datetime]",
+      HTMLElement,
+    ).length;
   }
 
   private activateControl(control: HTMLElement): void {

--- a/browser-extension/src/entrypoints/instagram.content/instagram-post-native-scraper.ts
+++ b/browser-extension/src/entrypoints/instagram.content/instagram-post-native-scraper.ts
@@ -15,6 +15,26 @@ import {
 } from "./instagram-comment-text-utils";
 
 const LOG_PREFIX = "[CS - InstagramPostNativeScraper] ";
+const REEL_COMMENT_CONTROL_SELECTOR =
+  "button, a, div[role='button'], [aria-label], [title], span, svg, title";
+const REEL_COMMENT_CONTROL_LABELS = [
+  "commenter",
+  "commentaire",
+  "commentaires",
+  "comment",
+  "comments",
+];
+const NON_REEL_COMMENT_CONTROL_LABELS = [
+  "options de commentaire",
+  "comment options",
+  "j'aime",
+  "like",
+  "likes",
+  "partager",
+  "share",
+  "envoyer",
+  "send",
+];
 
 type InstagramPostElements = {
   channelHeader: HTMLElement;
@@ -45,17 +65,29 @@ export class InstagramPostNativeScraper {
   async scrapPost(progressManager: ProgressManager): Promise<PostSnapshot> {
     this.debug("Start Scraping... ", document.URL);
 
-    if (this.isModalContext()) {
-      this.debug("Modal context detected, routing to modal scraper");
+    const url = document.URL;
+    const pageInfo = instagramPageInfo(url);
+    if (!pageInfo.isScrapablePost) {
+      throw new Error("Not on a scrapable page");
+    }
+
+    if (this.isReelUrl(url)) {
+      this.debug("Reel URL detected, trying to open comments panel");
+      const commentsPanelOpened = await this.openReelCommentsPanelIfNeeded();
+      if (!commentsPanelOpened) {
+        throw new Error("Could not open reel comments panel");
+      }
+      this.debug("Routing reel scraping to modal scraper");
       return new InstagramPostModalScraper(this.scrapingSupport).scrapPost(
         progressManager,
       );
     }
 
-    const url = document.URL;
-    const pageInfo = instagramPageInfo(url);
-    if (!pageInfo.isScrapablePost) {
-      throw new Error("Not on a scrapable page");
+    if (this.isModalContext()) {
+      this.debug("Modal context detected, routing to modal scraper");
+      return new InstagramPostModalScraper(this.scrapingSupport).scrapPost(
+        progressManager,
+      );
     }
 
     const scrapedAt = currentIsoDate();
@@ -117,6 +149,176 @@ export class InstagramPostNativeScraper {
     };
   }
 
+  private isReelUrl(url: string): boolean {
+    const parsedUrl = URL.parse(url);
+    if (!parsedUrl || parsedUrl.hostname !== INSTAGRAM_URL.hostname) {
+      return false;
+    }
+
+    return /\/(?:[^/]+\/)?reels?\//.test(parsedUrl.pathname);
+  }
+
+  private async openReelCommentsPanelIfNeeded(): Promise<boolean> {
+    if (this.isModalContext()) {
+      return true;
+    }
+
+    const commentControl = this.selectReelCommentControl();
+    if (!commentControl) {
+      this.debug("Could not find reel comment control");
+      return false;
+    }
+
+    this.activateControl(commentControl);
+    await this.scrapingSupport.sleep(300);
+
+    const waitResult = await this.scrapingSupport.waitForSelector(
+      document,
+      '[role="dialog"]',
+      HTMLElement,
+      {
+        timeout: 2500,
+        predicate: (dialogElement) =>
+          Boolean(
+            this.scrapingSupport.select(
+              dialogElement,
+              "time[datetime]",
+              HTMLElement,
+            ),
+          ),
+      },
+    );
+
+    if (waitResult.status === "failure") {
+      this.debug(
+        "Reel dialog not detected after comment click; trying inline reel layout",
+      );
+      return false;
+    }
+
+    this.debug("Reel comments panel opened");
+    return true;
+  }
+
+  private selectReelCommentControl(): HTMLElement | undefined {
+    const elements = Array.from(
+      document.querySelectorAll(REEL_COMMENT_CONTROL_SELECTOR),
+    );
+
+    for (const element of elements) {
+      const text = this.extractControlSearchText(element);
+      if (!text) {
+        continue;
+      }
+      if (
+        NON_REEL_COMMENT_CONTROL_LABELS.some((label) => text.includes(label)) ||
+        !REEL_COMMENT_CONTROL_LABELS.some((label) => text.includes(label))
+      ) {
+        continue;
+      }
+      const target = this.resolveClickableControl(element);
+      if (target) {
+        return target;
+      }
+    }
+
+    return undefined;
+  }
+
+  private activateControl(control: HTMLElement): void {
+    control.scrollIntoView({ block: "center", inline: "nearest" });
+    control.dispatchEvent(
+      new MouseEvent("mousedown", {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      }),
+    );
+    control.dispatchEvent(
+      new MouseEvent("mouseup", {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+      }),
+    );
+    control.click();
+    control.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    control.dispatchEvent(
+      new KeyboardEvent("keyup", {
+        key: "Enter",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+  }
+
+  private resolveClickableControl(element: Element): HTMLElement | undefined {
+    const clickableAncestor = element.closest("button, a, div[role='button']");
+    if (clickableAncestor instanceof HTMLElement) {
+      return clickableAncestor;
+    }
+
+    if (
+      element instanceof HTMLButtonElement ||
+      element instanceof HTMLAnchorElement ||
+      (element instanceof HTMLElement &&
+        element.getAttribute("role") === "button")
+    ) {
+      return element;
+    }
+
+    return undefined;
+  }
+
+  private extractControlSearchText(element: Element): string | undefined {
+    const values: Array<string | null | undefined> = [
+      element.textContent,
+      element.getAttribute("aria-label"),
+      element.getAttribute("title"),
+    ];
+
+    for (const labelledElement of Array.from(
+      element.querySelectorAll("[aria-label], [title], title"),
+    )) {
+      values.push(
+        labelledElement.textContent,
+        labelledElement.getAttribute("aria-label"),
+        labelledElement.getAttribute("title"),
+      );
+    }
+
+    const combinedText = values
+      .map((value) => this.normalizeSearchText(value))
+      .filter((value): value is string => Boolean(value))
+      .join(" ");
+
+    return combinedText || undefined;
+  }
+
+  private normalizeSearchText(
+    text: string | null | undefined,
+  ): string | undefined {
+    const normalized = text
+      ?.normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "")
+      .replace(/[’']/g, "'")
+      .replace(/\s+/g, " ")
+      .trim()
+      .toLowerCase();
+
+    if (!normalized) {
+      return undefined;
+    }
+
+    return normalized;
+  }
+
   private isPostMetadataEntry(
     comment: CommentSnapshot,
     postAuthor: Author,
@@ -135,7 +337,18 @@ export class InstagramPostNativeScraper {
   }
 
   private isModalContext(): boolean {
-    return Boolean(document.querySelector('[role="dialog"] article'));
+    for (const dialogElement of Array.from(
+      document.querySelectorAll('[role="dialog"]'),
+    )) {
+      if (
+        dialogElement instanceof HTMLElement &&
+        this.scrapingSupport.select(dialogElement, "time[datetime]", HTMLElement)
+      ) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private selectPostElements(): InstagramPostElements {

--- a/browser-extension/src/entrypoints/instagram.content/instagram-post-native-scraper.ts
+++ b/browser-extension/src/entrypoints/instagram.content/instagram-post-native-scraper.ts
@@ -342,7 +342,11 @@ export class InstagramPostNativeScraper {
     )) {
       if (
         dialogElement instanceof HTMLElement &&
-        this.scrapingSupport.select(dialogElement, "time[datetime]", HTMLElement)
+        this.scrapingSupport.select(
+          dialogElement,
+          "time[datetime]",
+          HTMLElement,
+        )
       ) {
         return true;
       }

--- a/browser-extension/src/entrypoints/instagram.content/instagramPageInfo.ts
+++ b/browser-extension/src/entrypoints/instagram.content/instagramPageInfo.ts
@@ -2,6 +2,7 @@ import { SocialNetwork } from "@/shared/model/SocialNetworkName";
 import { SocialNetworkPageInfo } from "@/shared/scraping-content-script/SocialNetworkPageInfo";
 
 export const INSTAGRAM_URL = new URL("https://www.instagram.com");
+const POST_ROUTE_SEGMENTS = new Set(["p", "reel", "reels"]);
 
 export function instagramPageInfo(url: string): SocialNetworkPageInfo {
   const parsed = URL.parse(url);
@@ -10,10 +11,14 @@ export function instagramPageInfo(url: string): SocialNetworkPageInfo {
       isScrapablePost: false,
     };
   }
-  const pathElements = parsed.pathname.substring(1).split("/");
+  const pathElements = parsed.pathname.substring(1).split("/").filter(Boolean);
 
-  if (pathElements.length > 1 && pathElements[0] === "p") {
-    // Url of style /p/<id>
+  if (
+    pathElements.length === 2 &&
+    POST_ROUTE_SEGMENTS.has(pathElements[0]) &&
+    Boolean(pathElements[1])
+  ) {
+    // Url of style /p/<id>, /reel/<id> or /reels/<id>
     const id = pathElements[1];
     return {
       isScrapablePost: true,
@@ -21,8 +26,12 @@ export function instagramPageInfo(url: string): SocialNetworkPageInfo {
       postId: id,
     };
   }
-  if (pathElements.length > 2 && pathElements[1] === "p") {
-    // Url of style /<account>/p/<id>
+  if (
+    pathElements.length === 3 &&
+    POST_ROUTE_SEGMENTS.has(pathElements[1]) &&
+    Boolean(pathElements[2])
+  ) {
+    // Url of style /<account>/p/<id> or /<account>/reel/<id>
     const id = pathElements[2];
     return {
       isScrapablePost: true,


### PR DESCRIPTION
## Résumé
- ajoute le support des URLs Instagram reels pour le scrapping
- ouvre explicitement le panneau commentaires sur les reels avant le scraping
- durcit la détection de la racine de scraping modal pour éviter les faux contextes
- prend en charge les contrôles de chargement supplémentaires (dont commentaires masqués) avec activation robuste

Closes #84

## Tests
- corepack pnpm lint
- corepack pnpm compile
- corepack pnpm test run src/entrypoints/instagram.content/__tests__/instagramPageInfo.test.ts

## Screenshot
<img width="2551" height="1216" alt="image" src="https://github.com/user-attachments/assets/31fa7fb7-e351-4aa7-a9a0-ed70bf65f549" />

