### PR TITLE
fix: polish posts UI and raw data developer table

### DIFF
--- a/browser-extension/src/entrypoints/posts/Developer/CommentTreeTable.tsx
+++ b/browser-extension/src/entrypoints/posts/Developer/CommentTreeTable.tsx
@@ -40,7 +40,7 @@ interface CommentTreeTableProps {
 
 export function CommentTreeTable({ comments }: CommentTreeTableProps) {
   const [expandedState, setExpandedState] = useState<ExpandedState>({});
-  const [showScreenshot, setShowScreenshot] = useState(false);
+  const [showScreenshot, setShowScreenshot] = useState(true);
   const [contentDialogOpen, setContentDialogOpen] = useState(false);
   const [screenshotDialogOpen, setScreenshotDialogOpen] = useState(false);
   const [selectedContent, setSelectedContent] = useState<{
@@ -166,7 +166,15 @@ export function CommentTreeTable({ comments }: CommentTreeTableProps) {
         cell: ({ row }) => {
           if (row.original.classifiedAt) {
             return (row.original.classification || []).map(
-              (category, index) => <Badge key={index}>{category}</Badge>,
+              (category, index) => (
+                <Badge
+                  key={index}
+                  variant="outline"
+                  className={getClassificationBadgeClassName(category)}
+                >
+                  {category}
+                </Badge>
+              ),
             );
           } else {
             return "Non ";
@@ -314,4 +322,27 @@ export function CommentTreeTable({ comments }: CommentTreeTableProps) {
       </Dialog>
     </div>
   );
+}
+
+function getClassificationBadgeClassName(category: string): string {
+  const normalizedCategory = category.toLowerCase();
+  if (normalizedCategory.includes("absence")) {
+    return "bg-green-100 border-green-200 text-green-800";
+  }
+  if (
+    normalizedCategory.includes("autre") ||
+    normalizedCategory.includes("cyberharcèlement")
+  ) {
+    return "bg-red-100 border-red-200 text-red-800";
+  }
+  if (normalizedCategory.includes("menace")) {
+    return "bg-orange-100 border-orange-200 text-orange-800";
+  }
+  if (
+    normalizedCategory.includes("insulte") ||
+    normalizedCategory.includes("injure")
+  ) {
+    return "bg-amber-100 border-amber-200 text-amber-900";
+  }
+  return "bg-slate-100 border-slate-200 text-slate-800";
 }

--- a/browser-extension/src/entrypoints/posts/Developer/PostSnapshotDetailPage.tsx
+++ b/browser-extension/src/entrypoints/posts/Developer/PostSnapshotDetailPage.tsx
@@ -9,6 +9,7 @@ import { UpdatePostWithClassificationResultMessage } from "../../background/clas
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Spinner } from "@/components/ui/spinner";
 import { isRunningClassificationStatus } from "@/shared/model/ClassificationStatus";
+import { getPublicationTypeLabel } from "@/shared/utils/post-util";
 
 function PostSnapshotDetailPage() {
   const params = useParams();
@@ -61,6 +62,8 @@ function PostSnapshotDetailPage() {
             >
               {post.author.name}
             </a>
+            {" · "}
+            {getPublicationTypeLabel(post.url, post.socialNetwork)}
           </h1>
           <div className="text-left">
             <Button
@@ -85,6 +88,13 @@ function PostSnapshotDetailPage() {
               Publiée le: <DisplayPublicationDate date={post.publishedAt} />
               <div>
                 Capturée le: {new Date(post.scrapedAt).toLocaleDateString()}
+              </div>
+              <div>Type: {getPublicationTypeLabel(post.url, post.socialNetwork)}</div>
+              <div className="break-all">
+                URL:{" "}
+                <a href={post.url} target="_blank" rel="noopener noreferrer">
+                  {post.url}
+                </a>
               </div>
             </div>
             <div className="italic">

--- a/browser-extension/src/entrypoints/posts/Developer/PostSnapshotDetailPage.tsx
+++ b/browser-extension/src/entrypoints/posts/Developer/PostSnapshotDetailPage.tsx
@@ -89,7 +89,9 @@ function PostSnapshotDetailPage() {
               <div>
                 Capturée le: {new Date(post.scrapedAt).toLocaleDateString()}
               </div>
-              <div>Type: {getPublicationTypeLabel(post.url, post.socialNetwork)}</div>
+              <div>
+                Type: {getPublicationTypeLabel(post.url, post.socialNetwork)}
+              </div>
               <div className="break-all">
                 URL:{" "}
                 <a href={post.url} target="_blank" rel="noopener noreferrer">

--- a/browser-extension/src/entrypoints/posts/Developer/PostSnapshotListPage.tsx
+++ b/browser-extension/src/entrypoints/posts/Developer/PostSnapshotListPage.tsx
@@ -197,7 +197,8 @@ function PostSnapshotListPage() {
                     <TableCell className="whitespace-normal break-all">
                       {post.classificationStatus ? (
                         <>
-                          {post.classificationStatus} ({post.classificationJobId})
+                          {post.classificationStatus} (
+                          {post.classificationJobId})
                         </>
                       ) : (
                         <>Non démarrée</>

--- a/browser-extension/src/entrypoints/posts/Developer/PostSnapshotListPage.tsx
+++ b/browser-extension/src/entrypoints/posts/Developer/PostSnapshotListPage.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router";
 import {
   getPostSnapshots as getPostsFromStorage,
   deleteAllPostSnapshots,
+  deletePostSnapshot,
 } from "../../../shared/storage/post-snapshot-storage";
 import { Button } from "@/components/ui/button";
 import {
@@ -20,8 +21,15 @@ import {
 } from "@/components/ui/tooltip";
 import DisplayPublicationDate from "./DisplayPublicationDate";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { RefreshCwIcon, TrashIcon } from "lucide-react";
+import {
+  InstagramIcon,
+  RefreshCwIcon,
+  TrashIcon,
+  YoutubeIcon,
+} from "lucide-react";
 import { countAllComments } from "@/shared/model/PostSnapshot";
+import { SocialNetwork } from "@/shared/model/SocialNetworkName";
+import { getSocialNetworkName } from "@/shared/utils/post-util";
 
 function PostSnapshotListPage() {
   const queryClient = useQueryClient();
@@ -48,113 +56,194 @@ function PostSnapshotListPage() {
     },
   });
 
+  const deleteOneMutation = useMutation({
+    mutationFn: deletePostSnapshot,
+    onSuccess: () => {
+      return queryClient.invalidateQueries({ queryKey: queryKey });
+    },
+  });
+
+  const confirmAndDeletePostSnapshot = (postId: string, postTitle?: string) => {
+    const targetLabel =
+      postTitle && postTitle.trim().length > 0
+        ? `"${ellipsis(postTitle, 80)}"`
+        : "cet élément";
+    const confirmed = window.confirm(
+      `Confirmer la suppression définitive de ${targetLabel} ?`,
+    );
+    if (!confirmed) {
+      return;
+    }
+    deleteOneMutation.mutate(postId);
+  };
+
+  const confirmAndDeleteAllPostSnapshots = () => {
+    const confirmed = window.confirm(
+      "Confirmer la suppression définitive de toutes les publications collectées ?",
+    );
+    if (!confirmed) {
+      return;
+    }
+    deleteAllMutation.mutate();
+  };
+
   return (
-    <div className="p-4">
+    <div className="p-4 flex flex-col gap-4 w-full max-w-full overflow-x-hidden">
       <h1>Publications collectées</h1>
 
       {postsQuery.isLoading && <Spinner className="size-8" />}
       {postsQuery.data && (
         <>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              refreshMutation.mutate();
-            }}
-          >
-            {refreshMutation.isPending ? (
-              <Spinner data-icon="inline-start" />
-            ) : (
-              <RefreshCwIcon data-icon="inline-start" />
-            )}
-            Recharger
-          </Button>
-          <Button
-            variant="destructive"
-            size="sm"
-            disabled={
-              postsQuery.data.length == 0 || deleteAllMutation.isPending
-            }
-            onClick={() => {
-              deleteAllMutation.mutate();
-            }}
-          >
-            {deleteAllMutation.isPending ? (
-              <Spinner data-icon="inline-start" />
-            ) : (
-              <TrashIcon data-icon="inline-start" />
-            )}
-            Tout supprimer
-          </Button>
-          <Table className="text-left">
-            <TableHeader>
-              <TableRow>
-                <TableHead>Collecte</TableHead>
-                <TableHead>Classification</TableHead>
-                <TableHead>Réseau social</TableHead>
-                <TableHead>Auteur</TableHead>
-                <TableHead>Publication</TableHead>
-                <TableHead>Aperçu contenu/description</TableHead>
-                <TableHead>Nb commentaires (racines/tous)</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {postsQuery.data.map((post, index) => (
-                <TableRow key={index}>
-                  <TableCell>
-                    <div>
-                      <Tooltip>
-                        <TooltipTrigger>
-                          {new Date(post.scrapedAt).toLocaleDateString()}
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          {new Date(post.scrapedAt).toLocaleDateString()}{" "}
-                          {new Date(post.scrapedAt).toTimeString()}
-                        </TooltipContent>
-                      </Tooltip>
-                    </div>
-                    <div>
-                      <Button
-                        variant="outline"
-                        size={"xs"}
-                        render={
-                          <Link to={"/post-snapshots/" + post.id}>
-                            D&eacute;tails
-                          </Link>
-                        }
-                      />
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    {post.classificationStatus ? (
-                      <>
-                        {post.classificationStatus} ({post.classificationJobId})
-                      </>
-                    ) : (
-                      <>Non démarrée</>
-                    )}
-                  </TableCell>
-                  <TableCell> {post.socialNetwork}</TableCell>
-                  <TableCell> {post.author.name}</TableCell>
-                  <TableCell>
-                    <a href={post.url} target="_blank" rel="noreferrer">
-                      <p>{post.title}</p>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                refreshMutation.mutate();
+              }}
+            >
+              {refreshMutation.isPending ? (
+                <Spinner data-icon="inline-start" />
+              ) : (
+                <RefreshCwIcon data-icon="inline-start" />
+              )}
+              Recharger
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              disabled={
+                postsQuery.data.length == 0 || deleteAllMutation.isPending
+              }
+              onClick={confirmAndDeleteAllPostSnapshots}
+            >
+              {deleteAllMutation.isPending ? (
+                <Spinner data-icon="inline-start" />
+              ) : (
+                <TrashIcon data-icon="inline-start" />
+              )}
+              Tout supprimer
+            </Button>
+          </div>
 
-                      <div className="text-muted-foreground">
-                        Publiée le{" "}
-                        <DisplayPublicationDate date={post.publishedAt} />
-                      </div>
-                    </a>
-                  </TableCell>
-                  <TableCell> {ellipsis(post.textContent || "")}</TableCell>
-
-                  <TableCell>
-                    {post.comments.length}/{countAllComments(post.comments)}
-                  </TableCell>
+          <div className="[&>[data-slot=table-container]]:overflow-x-hidden">
+            <Table className="w-full max-w-full text-left table-fixed [&_th]:align-top [&_td]:align-top">
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[11%] whitespace-normal">
+                    Collecte
+                  </TableHead>
+                  <TableHead className="w-[19%] whitespace-normal">
+                    Classification
+                  </TableHead>
+                  <TableHead className="w-[11%] whitespace-normal">
+                    Réseau social
+                  </TableHead>
+                  <TableHead className="w-[12%] whitespace-normal">
+                    Auteur
+                  </TableHead>
+                  <TableHead className="w-[22%] whitespace-normal">
+                    Publication
+                  </TableHead>
+                  <TableHead className="w-[15%] whitespace-normal">
+                    Aperçu contenu/description
+                  </TableHead>
+                  <TableHead className="w-[10%] whitespace-normal text-right">
+                    Nb commentaires (racines/tous)
+                  </TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {postsQuery.data.map((post, index) => (
+                  <TableRow key={index}>
+                    <TableCell className="whitespace-normal">
+                      <div className="space-y-2">
+                        <Tooltip>
+                          <TooltipTrigger>
+                            {new Date(post.scrapedAt).toLocaleDateString()}
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            {new Date(post.scrapedAt).toLocaleString()}
+                          </TooltipContent>
+                        </Tooltip>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <Button
+                            variant="outline"
+                            size={"xs"}
+                            render={
+                              <Link to={"/post-snapshots/" + post.id}>
+                                D&eacute;tails
+                              </Link>
+                            }
+                          />
+                          <Button
+                            variant="outline"
+                            size={"xs"}
+                            className="border-destructive text-destructive hover:bg-destructive/10"
+                            disabled={deleteOneMutation.isPending}
+                            onClick={() =>
+                              confirmAndDeletePostSnapshot(post.id, post.title)
+                            }
+                          >
+                            <TrashIcon
+                              data-icon="inline-start"
+                              className="size-3.5"
+                            />
+                            Supprimer
+                          </Button>
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell className="whitespace-normal break-all">
+                      {post.classificationStatus ? (
+                        <>
+                          {post.classificationStatus} ({post.classificationJobId})
+                        </>
+                      ) : (
+                        <>Non démarrée</>
+                      )}
+                    </TableCell>
+                    <TableCell className="whitespace-normal">
+                      <div className="inline-flex items-center gap-2">
+                        {post.socialNetwork === SocialNetwork.YouTube ? (
+                          <YoutubeIcon className="size-4 text-red-600" />
+                        ) : (
+                          <InstagramIcon className="size-4 text-pink-600" />
+                        )}
+                        <span>{getSocialNetworkName(post.socialNetwork)}</span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="whitespace-normal break-all">
+                      {post.author.name}
+                    </TableCell>
+                    <TableCell className="whitespace-normal">
+                      <div className="space-y-1">
+                        <a
+                          href={post.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="font-medium hover:underline break-all"
+                        >
+                          {post.title || post.url}
+                        </a>
+                        <div className="text-muted-foreground text-xs">
+                          Publiée le{" "}
+                          <DisplayPublicationDate date={post.publishedAt} />
+                        </div>
+                      </div>
+                    </TableCell>
+                    <TableCell className="whitespace-normal break-all">
+                      {post.textContent ? ellipsis(post.textContent, 140) : "—"}
+                    </TableCell>
+
+                    <TableCell className="whitespace-normal text-right tabular-nums">
+                      {post.comments.length}/{countAllComments(post.comments)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
         </>
       )}
     </div>
@@ -162,10 +251,11 @@ function PostSnapshotListPage() {
 }
 
 function ellipsis(str: string, maxLength: number = 50): string {
-  if (str.length <= maxLength) {
-    return str;
+  const normalized = str.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
   }
-  return str.substring(0, maxLength - 1) + "…";
+  return normalized.substring(0, maxLength - 1) + "…";
 }
 
 export default PostSnapshotListPage;

--- a/browser-extension/src/entrypoints/posts/Posts/PostDetailPage.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/PostDetailPage.tsx
@@ -9,6 +9,7 @@ import PostSummary from "../Shared/PostSummary";
 import KpiCard from "../Shared/KpiCards/KpiCard";
 import {
   formatAnalysisDate,
+  getPublicationTypeLabel,
   getSocialNetworkName,
   isCommentHateful,
 } from "@/shared/utils/post-util";
@@ -81,11 +82,15 @@ function PostDetailPage() {
             </div>
             <h2 className="text-left">Publication analysée</h2>
             <Card>
-              <CardContent className="flex gap-3">
+              <CardContent className="flex gap-3 justify-between">
                 <PostSummary post={post} />
-                <span className="">
-                  {getSocialNetworkName(post.socialNetwork)}
-                </span>
+                <div className="text-right text-muted-foreground whitespace-nowrap">
+                  <div>{getSocialNetworkName(post.socialNetwork)}</div>
+                  <div>
+                    Type:{" "}
+                    {getPublicationTypeLabel(post.url, post.socialNetwork)}
+                  </div>
+                </div>
               </CardContent>
             </Card>
             <div className="flex flex-col gap-3">

--- a/browser-extension/src/entrypoints/posts/Posts/PostListPage.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/PostListPage.tsx
@@ -10,6 +10,7 @@ import { Link } from "react-router";
 import PostSummary from "../Shared/PostSummary";
 import SearchSortFiltersPostList from "../Shared/SearchSortFiltersPostList";
 import { SocialNetwork } from "@/shared/model/SocialNetworkName";
+import { formatAnalysisDate } from "@/shared/utils/post-util";
 
 function PostListPage() {
   const [socialNetworkFilter, setSocialNetworkFilter] = React.useState<
@@ -72,17 +73,15 @@ function PostListPage() {
                   <PostSummary post={post} />
                   <Card className="bg-muted mt-2 flex flex-row px-5 py-3 items-center justify-between">
                     <div className="font-semibold">
-                      Analyse du{" "}
-                      {new Date(post.lastAnalysisDate).toLocaleDateString(
-                        undefined,
-                        {
-                          day: "numeric",
-                          month: "short",
-                        },
-                      )}
+                      Analyse du {formatAnalysisDate(post.lastAnalysisDate)}
                     </div>
                     <div>
-                      <Button variant="ghost" size="sm">
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        disabled
+                        className="text-muted-foreground opacity-60 cursor-not-allowed"
+                      >
                         Relancer l&apos;analyse
                       </Button>
                       <Button

--- a/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
@@ -9,6 +9,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import PostSummary from "../Shared/PostSummary";
 import { useForm } from "@tanstack/react-form";
 import { getFormId } from "./StepperComponents";
+import { formatAnalysisDate } from "@/shared/utils/post-util";
 
 function Step2Posts({
   reportQueryData,
@@ -40,8 +41,6 @@ function Step2Posts({
       return title.includes(searchValue) || description.includes(searchValue);
     });
   }, [data, searchTerm]);
-
-  console.log("render Step2Posts : ", { data, filteredPosts, searchTerm });
 
   const stepper = useStepper();
 
@@ -119,14 +118,7 @@ function Step2Posts({
                         <PostSummary post={post} />
                         <Card className="bg-muted mt-2 flex flex-row px-5 py-3 items-center justify-between">
                           <div className="font-semibold">
-                            Analyse du{" "}
-                            {new Date(post.lastAnalysisDate).toLocaleDateString(
-                              undefined,
-                              {
-                                day: "numeric",
-                                month: "short",
-                              },
-                            )}
+                            Analyse du {formatAnalysisDate(post.lastAnalysisDate)}
                           </div>
                         </Card>
                       </div>

--- a/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
@@ -118,7 +118,8 @@ function Step2Posts({
                         <PostSummary post={post} />
                         <Card className="bg-muted mt-2 flex flex-row px-5 py-3 items-center justify-between">
                           <div className="font-semibold">
-                            Analyse du {formatAnalysisDate(post.lastAnalysisDate)}
+                            Analyse du{" "}
+                            {formatAnalysisDate(post.lastAnalysisDate)}
                           </div>
                         </Card>
                       </div>

--- a/browser-extension/src/entrypoints/posts/Shared/ActiveAuthors.tsx
+++ b/browser-extension/src/entrypoints/posts/Shared/ActiveAuthors.tsx
@@ -76,7 +76,8 @@ function ActiveAuthors({
                     %
                   </TableCell>
                   <TableCell>
-                    {authorStats.numberOfComments} commentaires
+                    {authorStats.numberOfComments} commentaire
+                    {authorStats.numberOfComments > 1 ? "s" : ""}
                   </TableCell>
                 </TableRow>
               ))}

--- a/browser-extension/src/entrypoints/posts/Shared/SocialNetworkSelector.tsx
+++ b/browser-extension/src/entrypoints/posts/Shared/SocialNetworkSelector.tsx
@@ -16,7 +16,9 @@ function SocialNetworkSelector({
   onChange,
 }: SocialNetworkSelectorProps) {
   const selectedNetworks = value.filter((network) =>
-    SOCIAL_NETWORK_OPTIONS.includes(network as (typeof SOCIAL_NETWORK_OPTIONS)[number]),
+    SOCIAL_NETWORK_OPTIONS.includes(
+      network as (typeof SOCIAL_NETWORK_OPTIONS)[number],
+    ),
   );
 
   const toggleNetwork = (network: string) => {
@@ -44,7 +46,11 @@ function SocialNetworkSelector({
       >
         <Button
           type="button"
-          variant={selectedNetworks.includes(SocialNetwork.YouTube) ? "secondary" : "ghost"}
+          variant={
+            selectedNetworks.includes(SocialNetwork.YouTube)
+              ? "secondary"
+              : "ghost"
+          }
           size="sm"
           aria-pressed={selectedNetworks.includes(SocialNetwork.YouTube)}
           aria-label="Visualiser les résultats YouTube"

--- a/browser-extension/src/entrypoints/posts/Shared/SocialNetworkSelector.tsx
+++ b/browser-extension/src/entrypoints/posts/Shared/SocialNetworkSelector.tsx
@@ -1,4 +1,4 @@
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Button } from "@/components/ui/button";
 import { SocialNetwork } from "@/shared/model/SocialNetworkName";
 
 type SocialNetworkSelectorProps = Readonly<{
@@ -6,40 +6,67 @@ type SocialNetworkSelectorProps = Readonly<{
   onChange: (values: string[]) => void;
 }>;
 
+const SOCIAL_NETWORK_OPTIONS = [
+  SocialNetwork.YouTube,
+  SocialNetwork.Instagram,
+] as const;
+
 function SocialNetworkSelector({
   value,
   onChange,
 }: SocialNetworkSelectorProps) {
-  const handleChange = (newVals: string[]) => {
-    if (newVals.length === 0) {
+  const selectedNetworks = value.filter((network) =>
+    SOCIAL_NETWORK_OPTIONS.includes(network as (typeof SOCIAL_NETWORK_OPTIONS)[number]),
+  );
+
+  const toggleNetwork = (network: string) => {
+    const isSelected = selectedNetworks.includes(network);
+    if (isSelected && selectedNetworks.length === 1) {
       // prevent deselecting all options, at least one should be selected
       return;
     }
-    onChange(newVals);
+
+    const updated = isSelected
+      ? selectedNetworks.filter((item) => item !== network)
+      : [...selectedNetworks, network];
+    const ordered = SOCIAL_NETWORK_OPTIONS.filter((item) =>
+      updated.includes(item),
+    );
+    onChange(ordered);
   };
 
   return (
     <div className="p-3">
-      <ToggleGroup
-        multiple
-        variant="outline"
-        value={value}
-        onValueChange={handleChange}
+      <div
+        role="group"
         aria-label="Réseau social"
+        className="inline-flex rounded-md border border-input p-1 gap-1"
       >
-        <ToggleGroupItem
-          value={SocialNetwork.YouTube}
+        <Button
+          type="button"
+          variant={selectedNetworks.includes(SocialNetwork.YouTube) ? "secondary" : "ghost"}
+          size="sm"
+          aria-pressed={selectedNetworks.includes(SocialNetwork.YouTube)}
           aria-label="Visualiser les résultats YouTube"
+          onClick={() => toggleNetwork(SocialNetwork.YouTube)}
         >
           YouTube
-        </ToggleGroupItem>
-        <ToggleGroupItem
-          value={SocialNetwork.Instagram}
+        </Button>
+        <Button
+          type="button"
+          variant={
+            selectedNetworks.includes(SocialNetwork.Instagram)
+              ? "secondary"
+              : "ghost"
+          }
+          size="sm"
+          aria-pressed={selectedNetworks.includes(SocialNetwork.Instagram)}
           aria-label="Visualiser les résultats Instagram"
+          onClick={() => toggleNetwork(SocialNetwork.Instagram)}
         >
           Instagram
-        </ToggleGroupItem>
-      </ToggleGroup>
+        </Button>
+      </div>
     </div>
   );
 }

--- a/browser-extension/src/shared/utils/post-util.ts
+++ b/browser-extension/src/shared/utils/post-util.ts
@@ -52,3 +52,37 @@ export function getSocialNetworkName(socialNetwork: SocialNetworkName): string {
       return "";
   }
 }
+
+export function getPublicationTypeLabel(
+  postUrl: string,
+  socialNetwork: SocialNetworkName,
+): string {
+  try {
+    const parsedUrl = new URL(postUrl);
+    const pathname = parsedUrl.pathname.toLowerCase();
+
+    if (socialNetwork === SocialNetwork.YouTube) {
+      if (pathname.startsWith("/shorts/")) {
+        return "Short";
+      }
+      if (pathname === "/watch" || pathname.startsWith("/watch/")) {
+        return "Vidéo";
+      }
+      return "Publication";
+    }
+
+    if (socialNetwork === SocialNetwork.Instagram) {
+      if (pathname.startsWith("/reel/") || pathname.startsWith("/reels/")) {
+        return "Reel";
+      }
+      if (pathname.startsWith("/p/")) {
+        return "Post (page ou modal)";
+      }
+      return "Publication";
+    }
+  } catch {
+    return "Inconnu";
+  }
+
+  return "Publication";
+}


### PR DESCRIPTION
## Résumé
Cette PR regroupe plusieurs correctifs UX/UI sur les vues `Posts` et `[Dev] Données brutes`.

## Changements
- corrige la pluralisation dans la vue d’ensemble : `1 commentaire` / `N commentaires`
- affiche la date et l’heure exactes d’analyse dans `Publications analysées`
- applique la même amélioration de date/heure dans l’étape 2 du rapport
- améliore la page `[Dev] Données brutes` pour les contenus longs : colonnes rééquilibrées, retour à la ligne, meilleure lisibilité des cellules
- ajoute un bouton `Supprimer` par ligne dans `[Dev] Données brutes`
- ajoute une confirmation avant suppression d’une ligne
- ajoute une confirmation avant `Tout supprimer`
- ajoute les icônes réseau (YouTube / Instagram) dans le tableau dev
- affiche les noms réseau en lisible (`YouTube`, `Instagram`) au lieu des valeurs en capslock
- corrige l’alignement visuel des boutons `Détails` / `Supprimer`
- grise explicitement le bouton `Relancer l’analyse` (inactif pour l’instant)
- affiche le type de publication (`Short`, `Reel`, `Post...`) sur les vues détail (YouTube / Instagram)
- affiche explicitement l’URL de la publication sur la vue détail dev
- applique des couleurs de badge plus logiques pour les catégories de classification
- affiche les captures d’écran par défaut dans le tableau des commentaires de la vue dev
- remplace le sélecteur YouTube/Instagram par une version contrôlée pour éviter les états visuels incohérents (actif/grisé)

## Validation
- `corepack pnpm --dir browser-extension compile`
- `corepack pnpm --dir browser-extension lint`