### PR TITLE
[Front] feat(report): add pdf download generation

### DIFF
--- a/browser-extension/package.json
+++ b/browser-extension/package.json
@@ -30,6 +30,7 @@
     "@base-ui/react": "^1.1.0",
     "@fontsource-variable/red-hat-display": "^5.2.8",
     "@fontsource-variable/red-hat-text": "^5.2.8",
+    "@react-pdf/renderer": "^4.4.1",
     "@stepperize/react": "^6.1.0",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-form": "^1.28.5",

--- a/browser-extension/pnpm-lock.yaml
+++ b/browser-extension/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@fontsource-variable/red-hat-text':
         specifier: ^5.2.8
         version: 5.2.8
+      '@react-pdf/renderer':
+        specifier: ^4.4.1
+        version: 4.5.1(react@19.2.3)
       '@stepperize/react':
         specifier: ^6.1.0
         version: 6.1.0(react@19.2.3)(typescript@5.9.3)
@@ -755,6 +758,14 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -786,6 +797,49 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@react-pdf/fns@3.1.3':
+    resolution: {integrity: sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==}
+
+  '@react-pdf/font@4.0.8':
+    resolution: {integrity: sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==}
+
+  '@react-pdf/image@3.1.0':
+    resolution: {integrity: sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==}
+
+  '@react-pdf/layout@4.6.1':
+    resolution: {integrity: sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==}
+
+  '@react-pdf/pdfkit@5.1.1':
+    resolution: {integrity: sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==}
+
+  '@react-pdf/primitives@4.3.0':
+    resolution: {integrity: sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==}
+
+  '@react-pdf/reconciler@2.0.0':
+    resolution: {integrity: sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-pdf/render@4.5.1':
+    resolution: {integrity: sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==}
+
+  '@react-pdf/renderer@4.5.1':
+    resolution: {integrity: sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-pdf/stylesheet@6.2.1':
+    resolution: {integrity: sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==}
+
+  '@react-pdf/svg@1.1.0':
+    resolution: {integrity: sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==}
+
+  '@react-pdf/textkit@6.3.0':
+    resolution: {integrity: sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==}
+
+  '@react-pdf/types@2.11.1':
+    resolution: {integrity: sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==}
 
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
@@ -1005,6 +1059,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@swc/helpers@0.5.21':
+    resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
 
   '@tailwindcss/node@4.1.18':
     resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
@@ -1390,6 +1447,9 @@ packages:
   '@wxt-dev/storage@1.2.6':
     resolution: {integrity: sha512-f6AknnpJvhNHW4s0WqwSGCuZAj0fjP3EVNPBO5kB30pY+3Zt/nqZGqJN6FgBLCSkYjPJ8VL1hNX5LMVmvxQoDw==}
 
+  abs-svg-path@0.1.1:
+    resolution: {integrity: sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1527,9 +1587,19 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.9.14:
     resolution: {integrity: sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   binary-search@1.3.6:
     resolution: {integrity: sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==}
@@ -1560,6 +1630,12 @@ packages:
 
   bresenham-zingl@0.2.5:
     resolution: {integrity: sha512-0TCrPvavRM/3Os9QIUDhe8jpAQXgEYjsVO+9IKnkC8cdzorDX5fMRfr3neEFGjcfRItEswHvIvPrqQzCalRYkw==}
+
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
+
+  browserify-zlib@0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
@@ -1680,6 +1756,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1690,6 +1770,14 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-name@2.1.0:
+    resolution: {integrity: sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==}
+    engines: {node: '>=12.20'}
+
+  color-string@2.1.4:
+    resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
+    engines: {node: '>=18'}
 
   colord@2.9.3:
     resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
@@ -1853,6 +1941,9 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  dfa@1.2.0:
+    resolution: {integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -1906,6 +1997,9 @@ packages:
 
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
+
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -2069,6 +2163,10 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -2163,6 +2261,9 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+
+  fontkit@2.0.4:
+    resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -2332,6 +2433,12 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  hsl-to-hex@1.0.0:
+    resolution: {integrity: sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==}
+
+  hsl-to-rgb-for-reals@1.1.1:
+    resolution: {integrity: sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -2344,6 +2451,9 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  hyphen@1.14.1:
+    resolution: {integrity: sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2568,6 +2678,9 @@ packages:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
 
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -2620,12 +2733,18 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jay-peg@1.1.1:
+    resolution: {integrity: sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   jpeg-js@0.4.4:
     resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
+  js-md5@0.8.3:
+    resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
 
   js-priority-queue@0.1.5:
     resolution: {integrity: sha512-2dPmJT4GbXUpob7AZDR1wFMKz3Biy6oW69mwt5PTtdeoOgDin1i0p5gUV9k0LFeUxDpwkfr+JGMZDpcprjiY5w==}
@@ -2771,6 +2890,9 @@ packages:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
     engines: {node: '>= 12.0.0'}
 
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
   lines-and-columns@2.0.4:
     resolution: {integrity: sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2900,6 +3022,9 @@ packages:
 
   mdn-data@2.23.0:
     resolution: {integrity: sha512-786vq1+4079JSeu2XdcDjrhi/Ry7BWtjDl9WtGPWLiIHb2T66GvIVflZTBoSNZ5JqTtJGYEVMuFA/lbQlMOyDQ==}
+
+  media-engine@1.0.3:
+    resolution: {integrity: sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==}
 
   median-quickselect@1.0.1:
     resolution: {integrity: sha512-/QL9ptNuLsdA68qO+2o10TKCyu621zwwTFdLvtu8rzRNKsn8zvuGoq/vDxECPyELFG8wu+BpyoMR9BnsJqfVZQ==}
@@ -3128,6 +3253,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-svg-path@1.1.0:
+    resolution: {integrity: sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==}
+
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -3217,6 +3345,9 @@ packages:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
     engines: {node: '>=18'}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
@@ -3233,6 +3364,9 @@ packages:
   parse-json@7.1.1:
     resolution: {integrity: sha512-SgOTCX/EZXtZxBE5eJ97P4yGM5n37BwRU+YMsH4vNzFqJV/oWFXXCmwFlgWUM4PrakybVOueJJ6pwHqSVhTFDw==}
     engines: {node: '>=16'}
+
+  parse-svg-path@0.1.2:
+    resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3300,6 +3434,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  png-js@2.0.0:
+    resolution: {integrity: sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==}
+
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
@@ -3307,6 +3444,9 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -3362,6 +3502,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -3460,6 +3603,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
@@ -3482,6 +3629,9 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  restructure@3.0.2:
+    resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -3539,6 +3689,9 @@ packages:
   sax@1.4.4:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
+
+  scheduler@0.25.0-rc-603e6108-20241029:
+    resolution: {integrity: sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3776,6 +3929,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-arc-to-cubic-bezier@3.2.0:
+    resolution: {integrity: sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==}
+
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
@@ -3797,6 +3953,9 @@ packages:
 
   tiff@7.1.3:
     resolution: {integrity: sha512-YEEq3fT++2pdta/9P/vGG4QRMdZQoe6W6JNaWnIi6NvAsbeNITwFCtmWwL/BZvOi+uo2I3ohyOkD3sZfme+c6g==}
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -3945,6 +4104,12 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  unicode-properties@1.4.1:
+    resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
+
   unimport@5.6.0:
     resolution: {integrity: sha512-8rqAmtJV8o60x46kBAJKtHpJDJWkA2xcBqWKPI14MgUb05o1pnpnCnXSxedUXyeq7p8fR5g3pTo2BaswZ9lD9A==}
     engines: {node: '>=18.12.0'}
@@ -3997,6 +4162,10 @@ packages:
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
+
+  vite-compatible-readable-stream@3.6.1:
+    resolution: {integrity: sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==}
+    engines: {node: '>= 6'}
 
   vite-node@5.2.0:
     resolution: {integrity: sha512-7UT39YxUukIA97zWPXUGb0SGSiLexEGlavMwU3HDE6+d/HJhKLjLqu4eX2qv6SQiocdhKLRcusroDwXHQ6CnRQ==}
@@ -4205,6 +4374,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   zip-dir@2.0.0:
     resolution: {integrity: sha512-uhlsJZWz26FLYXOD6WVuq+fIcZ3aBPGo/cFdiLlv3KNwpa52IF3ISV8fLhQLiqVu5No3VhlqlgthN6gehil1Dg==}
@@ -4733,6 +4905,10 @@ snapshots:
       '@types/react': 19.2.8
       react: 19.2.3
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4763,6 +4939,110 @@ snapshots:
 
   '@polka/url@1.0.0-next.29':
     optional: true
+
+  '@react-pdf/fns@3.1.3': {}
+
+  '@react-pdf/font@4.0.8':
+    dependencies:
+      '@react-pdf/pdfkit': 5.1.1
+      '@react-pdf/types': 2.11.1
+      fontkit: 2.0.4
+      is-url: 1.2.4
+
+  '@react-pdf/image@3.1.0':
+    dependencies:
+      '@react-pdf/svg': 1.1.0
+      jay-peg: 1.1.1
+      png-js: 2.0.0
+
+  '@react-pdf/layout@4.6.1':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/image': 3.1.0
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/stylesheet': 6.2.1
+      '@react-pdf/textkit': 6.3.0
+      '@react-pdf/types': 2.11.1
+      emoji-regex-xs: 1.0.0
+      queue: 6.0.2
+      yoga-layout: 3.2.1
+
+  '@react-pdf/pdfkit@5.1.1':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@noble/ciphers': 1.3.0
+      '@noble/hashes': 1.8.0
+      browserify-zlib: 0.2.0
+      fontkit: 2.0.4
+      jay-peg: 1.1.1
+      js-md5: 0.8.3
+      linebreak: 1.1.0
+      png-js: 2.0.0
+      vite-compatible-readable-stream: 3.6.1
+
+  '@react-pdf/primitives@4.3.0': {}
+
+  '@react-pdf/reconciler@2.0.0(react@19.2.3)':
+    dependencies:
+      object-assign: 4.1.1
+      react: 19.2.3
+      scheduler: 0.25.0-rc-603e6108-20241029
+
+  '@react-pdf/render@4.5.1':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/textkit': 6.3.0
+      '@react-pdf/types': 2.11.1
+      abs-svg-path: 0.1.1
+      color-string: 2.1.4
+      normalize-svg-path: 1.1.0
+      parse-svg-path: 0.1.2
+      svg-arc-to-cubic-bezier: 3.2.0
+
+  '@react-pdf/renderer@4.5.1(react@19.2.3)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/font': 4.0.8
+      '@react-pdf/layout': 4.6.1
+      '@react-pdf/pdfkit': 5.1.1
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/reconciler': 2.0.0(react@19.2.3)
+      '@react-pdf/render': 4.5.1
+      '@react-pdf/types': 2.11.1
+      events: 3.3.0
+      object-assign: 4.1.1
+      prop-types: 15.8.1
+      queue: 6.0.2
+      react: 19.2.3
+
+  '@react-pdf/stylesheet@6.2.1':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/types': 2.11.1
+      color-string: 2.1.4
+      hsl-to-hex: 1.0.0
+      media-engine: 1.0.3
+      postcss-value-parser: 4.2.0
+
+  '@react-pdf/svg@1.1.0':
+    dependencies:
+      '@react-pdf/primitives': 4.3.0
+
+  '@react-pdf/textkit@6.3.0':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      bidi-js: 1.0.3
+      hyphen: 1.14.1
+      unicode-properties: 1.4.1
+
+  '@react-pdf/types@2.11.1':
+    dependencies:
+      '@react-pdf/font': 4.0.8
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/stylesheet': 6.2.1
 
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
@@ -4953,6 +5233,10 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
+
+  '@swc/helpers@0.5.21':
+    dependencies:
+      tslib: 2.8.1
 
   '@tailwindcss/node@4.1.18':
     dependencies:
@@ -5418,6 +5702,8 @@ snapshots:
       async-mutex: 0.5.0
       dequal: 2.0.3
 
+  abs-svg-path@0.1.1: {}
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -5561,7 +5847,15 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@0.0.8: {}
+
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.9.14: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   binary-search@1.3.6: {}
 
@@ -5598,6 +5892,14 @@ snapshots:
       fill-range: 7.1.1
 
   bresenham-zingl@0.2.5: {}
+
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
 
   browserslist@4.28.1:
     dependencies:
@@ -5726,6 +6028,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clone@2.1.2: {}
+
   clsx@2.1.1: {}
 
   color-convert@2.0.1:
@@ -5733,6 +6037,12 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  color-name@2.1.0: {}
+
+  color-string@2.1.4:
+    dependencies:
+      color-name: 2.1.0
 
   colord@2.9.3: {}
 
@@ -5876,6 +6186,8 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  dfa@1.2.0: {}
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
@@ -5934,6 +6246,8 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.267: {}
+
+  emoji-regex-xs@1.0.0: {}
 
   emoji-regex@10.6.0: {}
 
@@ -6211,6 +6525,8 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  events@3.3.0: {}
+
   expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
@@ -6295,6 +6611,18 @@ snapshots:
   flatted@3.3.3: {}
 
   follow-redirects@1.15.11: {}
+
+  fontkit@2.0.4:
+    dependencies:
+      '@swc/helpers': 0.5.21
+      brotli: 1.3.3
+      clone: 2.1.2
+      dfa: 1.2.0
+      fast-deep-equal: 3.1.3
+      restructure: 3.0.2
+      tiny-inflate: 1.0.3
+      unicode-properties: 1.4.1
+      unicode-trie: 2.0.0
 
   for-each@0.3.5:
     dependencies:
@@ -6459,6 +6787,12 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  hsl-to-hex@1.0.0:
+    dependencies:
+      hsl-to-rgb-for-reals: 1.1.1
+
+  hsl-to-rgb-for-reals@1.1.1: {}
+
   html-escaper@2.0.2: {}
 
   html-escaper@3.0.3: {}
@@ -6476,6 +6810,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  hyphen@1.14.1: {}
 
   ignore@5.3.2: {}
 
@@ -6690,6 +7026,8 @@ snapshots:
 
   is-unicode-supported@2.1.0: {}
 
+  is-url@1.2.4: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -6741,9 +7079,15 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jay-peg@1.1.1:
+    dependencies:
+      restructure: 3.0.2
+
   jiti@2.6.1: {}
 
   jpeg-js@0.4.4: {}
+
+  js-md5@0.8.3: {}
 
   js-priority-queue@0.1.5: {}
 
@@ -6865,6 +7209,11 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
 
   lines-and-columns@2.0.4: {}
 
@@ -7074,6 +7423,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.23.0: {}
+
+  media-engine@1.0.3: {}
 
   median-quickselect@1.0.1: {}
 
@@ -7426,6 +7777,10 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  normalize-svg-path@1.1.0:
+    dependencies:
+      svg-arc-to-cubic-bezier: 3.2.0
+
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -7547,6 +7902,8 @@ snapshots:
       registry-url: 6.0.1
       semver: 7.7.3
 
+  pako@0.2.9: {}
+
   pako@1.0.11: {}
 
   pako@2.1.0: {}
@@ -7564,6 +7921,8 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       lines-and-columns: 2.0.4
       type-fest: 3.13.1
+
+  parse-svg-path@0.1.2: {}
 
   path-exists@4.0.0: {}
 
@@ -7633,10 +7992,16 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  png-js@2.0.0:
+    dependencies:
+      fflate: 0.8.2
+
   pngjs@7.0.0:
     optional: true
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-value-parser@4.2.0: {}
 
   postcss@8.5.6:
     dependencies:
@@ -7695,6 +8060,10 @@ snapshots:
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
 
   quick-format-unescaped@4.0.4: {}
 
@@ -7816,6 +8185,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
@@ -7838,6 +8209,8 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  restructure@3.0.2: {}
 
   reusify@1.1.0: {}
 
@@ -7924,6 +8297,8 @@ snapshots:
   safe-stable-stringify@2.5.0: {}
 
   sax@1.4.4: {}
+
+  scheduler@0.25.0-rc-603e6108-20241029: {}
 
   scheduler@0.27.0: {}
 
@@ -8233,6 +8608,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-arc-to-cubic-bezier@3.2.0: {}
+
   tabbable@6.4.0: {}
 
   tailwind-merge@3.4.0: {}
@@ -8251,6 +8628,8 @@ snapshots:
     dependencies:
       fflate: 0.8.2
       iobuffer: 6.0.1
+
+  tiny-inflate@1.0.3: {}
 
   tiny-invariant@1.3.3: {}
 
@@ -8386,6 +8765,16 @@ snapshots:
 
   undici-types@7.19.2: {}
 
+  unicode-properties@1.4.1:
+    dependencies:
+      base64-js: 1.5.1
+      unicode-trie: 2.0.0
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
+
   unimport@5.6.0:
     dependencies:
       acorn: 8.15.0
@@ -8466,6 +8855,12 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@8.3.2: {}
+
+  vite-compatible-readable-stream@3.6.1:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
 
   vite-node@5.2.0(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
@@ -8762,6 +9157,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yoga-layout@3.2.1: {}
 
   zip-dir@2.0.0:
     dependencies:

--- a/browser-extension/src/entrypoints/posts/Report/DownloadPdfButton.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/DownloadPdfButton.tsx
@@ -6,6 +6,7 @@ import { PdfReport } from "./PdfReport";
 import { Post } from "@/shared/model/post/Post";
 import { REPORT_PDF_FILE_NAME } from "@/shared/utils/report-data";
 import { ReportQueryData } from "./BuildReport";
+import { DOWNLOAD_PDF_LABEL } from "@/shared/constants/labels";
 
 interface DownloadPdfButtonProps {
   reportQueryData: ReportQueryData;
@@ -29,7 +30,7 @@ export const DownloadPdfButton = ({
   if (instance.loading || !instance.url || instance.error) {
     return (
       <Button disabled>
-        {instance.loading ? "Génération..." : "Télécharger le PDF"}
+        {instance.loading ? "Génération..." : DOWNLOAD_PDF_LABEL}
       </Button>
     );
   }
@@ -43,7 +44,7 @@ export const DownloadPdfButton = ({
           target="_blank"
           rel="noreferrer"
         >
-          Télécharger le PDF
+          {DOWNLOAD_PDF_LABEL}
         </a>
       }
     />

--- a/browser-extension/src/entrypoints/posts/Report/DownloadPdfButton.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/DownloadPdfButton.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useMemo } from "react";
+
+import { usePDF } from "@react-pdf/renderer";
+import { Button } from "@/components/ui/button";
+import { PdfReport } from "./PdfReport";
+import { Post } from "@/shared/model/post/Post";
+import { REPORT_PDF_FILE_NAME } from "@/shared/utils/report-data";
+import { ReportQueryData } from "./BuildReport";
+
+interface DownloadPdfButtonProps {
+  reportQueryData: ReportQueryData;
+  posts: Post[];
+}
+
+export const DownloadPdfButton = ({
+  reportQueryData,
+  posts,
+}: DownloadPdfButtonProps) => {
+  const pdfDocument = useMemo(
+    () => <PdfReport reportQueryData={reportQueryData} posts={posts} />,
+    [posts, reportQueryData],
+  );
+  const [instance, updateInstance] = usePDF();
+
+  useEffect(() => {
+    updateInstance(pdfDocument);
+  }, [pdfDocument, updateInstance]);
+
+  if (instance.loading || !instance.url || instance.error) {
+    return (
+      <Button disabled>
+        {instance.loading ? "Génération..." : "Télécharger le PDF"}
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      render={
+        <a
+          href={instance.url}
+          download={REPORT_PDF_FILE_NAME}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Télécharger le PDF
+        </a>
+      }
+    />
+  );
+};

--- a/browser-extension/src/entrypoints/posts/Report/PdfReport.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/PdfReport.tsx
@@ -1,0 +1,357 @@
+import {
+  Document,
+  Image,
+  Page,
+  StyleSheet,
+  Text,
+  View,
+} from "@react-pdf/renderer";
+import { Post } from "@/shared/model/post/Post";
+import { buildDataUrl, PNG_MIME_TYPE } from "@/shared/utils/data-url";
+import {
+  formatAnalysisDate,
+  getSocialNetworkName,
+} from "@/shared/utils/post-util";
+import { PublicationDate, RelativeDate } from "@/shared/model/PublicationDate";
+import { SocialNetworkName } from "@/shared/model/SocialNetworkName";
+import { getEntriesGroupedByPostKey } from "@/shared/utils/report-data";
+import {
+  getAuthorStatsList,
+  getNumberOfHatefulAuthors,
+} from "@/shared/utils/report-stats";
+import { getPercentage } from "@/shared/utils/maths";
+import { ReportQueryData } from "./BuildReport";
+
+const GRAY_200 = "#e5e7eb";
+const GRAY_500 = "#6b7280";
+const BORDER = "#e5e7eb";
+const pxToPt = (pixels: number) => pixels * 0.75;
+const CARD_RADIUS = pxToPt(12);
+
+const styles = StyleSheet.create({
+  page: {
+    padding: pxToPt(28),
+    fontSize: pxToPt(14),
+    color: "#171717",
+  },
+
+  metaBlock: {
+    flexDirection: "column",
+    alignItems: "flex-end",
+    marginBottom: pxToPt(8),
+  },
+  metaLine: { fontSize: pxToPt(12), marginBottom: pxToPt(2) },
+  metaBold: { fontWeight: 700 },
+
+  pageTitle: {
+    fontSize: pxToPt(20),
+    fontWeight: 700,
+    textAlign: "center",
+    marginBottom: pxToPt(16),
+  },
+
+  kpiRow: { flexDirection: "row", gap: pxToPt(16), marginBottom: pxToPt(16) },
+  kpiCard: {
+    flex: 1,
+    border: `1px solid ${BORDER}`,
+    borderRadius: CARD_RADIUS,
+    padding: pxToPt(12),
+  },
+  kpiLabel: {
+    fontSize: pxToPt(14),
+    color: GRAY_500,
+    marginBottom: pxToPt(4),
+  },
+  kpiValue: { fontSize: pxToPt(18), fontWeight: 700 },
+
+  twoColRow: {
+    flexDirection: "row",
+    gap: pxToPt(24),
+    marginBottom: pxToPt(16),
+  },
+  twoColCard: {
+    flex: 1,
+    border: `1px solid ${BORDER}`,
+    borderRadius: CARD_RADIUS,
+  },
+  cardHeader: {
+    padding: `${pxToPt(24)}px ${pxToPt(24)}px ${pxToPt(8)}px`,
+    fontSize: pxToPt(12),
+    fontWeight: 400,
+  },
+  cardContent: { padding: `0 ${pxToPt(16)}px ${pxToPt(16)}px` },
+
+  tableHeaderRow: {
+    flexDirection: "row",
+    backgroundColor: GRAY_200,
+    minHeight: pxToPt(40),
+    padding: `${pxToPt(8)}px ${pxToPt(8)}px`,
+    alignItems: "center",
+  },
+  tableDataRow: {
+    flexDirection: "row",
+    padding: `${pxToPt(8)}px`,
+    borderBottom: `1px solid ${BORDER}`,
+    alignItems: "center",
+  },
+  tableHeaderCell: { fontWeight: 500, fontSize: pxToPt(10) },
+  tableCell: { fontSize: pxToPt(10) },
+  colAuthorName: { width: "40%" },
+  colRatio: { width: "30%" },
+  colCount: { width: "30%" },
+
+  postSection: { marginBottom: pxToPt(16) },
+  postSummaryCard: {
+    border: `1px solid ${BORDER}`,
+    borderRadius: CARD_RADIUS,
+    padding: pxToPt(20),
+    marginBottom: pxToPt(8),
+    flexDirection: "row",
+  },
+  postCoverImage: {
+    width: pxToPt(192),
+    height: pxToPt(128),
+    marginRight: pxToPt(16),
+    borderRadius: pxToPt(4),
+    objectFit: "cover",
+  },
+  postInfoBlock: { flex: 1 },
+  postTitle: { fontSize: pxToPt(14), fontWeight: 600, marginBottom: pxToPt(4) },
+  postMeta: { fontSize: pxToPt(10), marginBottom: pxToPt(4) },
+
+  commentsTable: {
+    border: `1px solid ${BORDER}`,
+    borderRadius: 8,
+    overflow: "hidden",
+    marginBottom: 4,
+  },
+  colCommentAuthor: { width: "22%" },
+  colCommentScreenshot: { width: "58%" },
+  colCommentDate: { width: "20%" },
+  screenshotImage: { maxWidth: "100%", maxHeight: pxToPt(140) },
+  naText: { color: "#9ca3af" },
+  pagination: { fontSize: pxToPt(10), color: GRAY_500 },
+  categoryDescription: { fontSize: pxToPt(10), lineHeight: 1.4 },
+});
+
+const formatPublicationDate = (publishedAt: PublicationDate): string => {
+  switch (publishedAt.type) {
+    case "absolute":
+      return new Date(publishedAt.date).toLocaleDateString("fr-FR");
+    case "relative":
+      return formatRelativeDate(publishedAt);
+    case "unknown date":
+      return publishedAt.dateText;
+  }
+};
+
+const formatRelativeDate = (relative: RelativeDate): string => {
+  const start = new Date(relative.resolvedDateRange.start).getTime();
+  const end = new Date(relative.resolvedDateRange.end).getTime();
+  const mid = new Date(start + Math.round((end - start) / 2));
+  return `~${mid.toLocaleDateString("fr-FR")}`;
+};
+
+const KpiCard = ({ label, value }: { label: string; value: string }) => {
+  return (
+    <View style={styles.kpiCard}>
+      <Text style={styles.kpiLabel}>{label}</Text>
+      <Text style={styles.kpiValue}>{value}</Text>
+    </View>
+  );
+};
+
+interface PdfReportProps {
+  reportQueryData: ReportQueryData;
+  posts: Post[];
+}
+
+export const PdfReport = ({ reportQueryData, posts }: PdfReportProps) => {
+  const { postCommentList } = reportQueryData;
+
+  const numberOfHatefulComments = postCommentList.length;
+  const numberOfComments = posts.flatMap((p) => p.comments).length;
+  const percentageHateful = getPercentage(
+    numberOfHatefulComments,
+    numberOfComments,
+  ).toFixed(2);
+  const numberOfHatefulAuthors = getNumberOfHatefulAuthors(postCommentList);
+  const authorStatsList = getAuthorStatsList(postCommentList);
+
+  const groupedCommentsByPost = getEntriesGroupedByPostKey(postCommentList);
+
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        <View style={styles.metaBlock}>
+          <Text style={styles.metaLine}>
+            Généré le{" "}
+            <Text style={styles.metaBold}>
+              {formatAnalysisDate(new Date().toISOString())}
+            </Text>
+          </Text>
+          <Text style={styles.metaLine}>
+            Publications analysées :{" "}
+            <Text style={styles.metaBold}>
+              {reportQueryData.postIdList.length}
+            </Text>
+          </Text>
+          <Text style={styles.metaLine}>
+            Plateforme :{" "}
+            <Text style={styles.metaBold}>
+              {reportQueryData.socialNetworkList
+                .map((n) => getSocialNetworkName(n as SocialNetworkName))
+                .join(", ")}
+            </Text>
+          </Text>
+        </View>
+
+        <Text style={styles.pageTitle}>
+          Rapport des commentaires malveillants
+        </Text>
+
+        <View style={styles.kpiRow}>
+          <KpiCard
+            label="Nombre de commentaires malveillants"
+            value={`${numberOfHatefulComments}/${numberOfComments}`}
+          />
+          <KpiCard
+            label="Part des commentaires malveillants"
+            value={`${percentageHateful}%`}
+          />
+          <KpiCard
+            label="Auteurs de commentaires malveillants"
+            value={String(numberOfHatefulAuthors)}
+          />
+          <KpiCard label="Gravité" value="Modérée" />
+        </View>
+
+        <View style={styles.twoColRow}>
+          <View style={styles.twoColCard}>
+            <Text style={styles.cardHeader}>Auteurs actifs</Text>
+            <View style={styles.cardContent}>
+              <View style={styles.tableHeaderRow}>
+                <Text style={[styles.tableHeaderCell, styles.colAuthorName]}>
+                  Auteur
+                </Text>
+                <Text style={[styles.tableHeaderCell, styles.colRatio]}>
+                  % haineux
+                </Text>
+                <Text style={[styles.tableHeaderCell, styles.colCount]}>
+                  Commentaires
+                </Text>
+              </View>
+              {authorStatsList.map((author) => (
+                <View key={author.name} style={styles.tableDataRow}>
+                  <Text style={[styles.tableCell, styles.colAuthorName]}>
+                    {author.name}
+                  </Text>
+                  <Text style={[styles.tableCell, styles.colRatio]}>
+                    {getPercentage(
+                      author.numberOfHatefulComments,
+                      author.numberOfComments,
+                    ).toFixed(2)}
+                    %
+                  </Text>
+                  <Text style={[styles.tableCell, styles.colCount]}>
+                    {author.numberOfComments} commentaire
+                    {author.numberOfComments > 1 ? "s" : ""}
+                  </Text>
+                </View>
+              ))}
+            </View>
+          </View>
+
+          <View style={styles.twoColCard}>
+            <Text style={styles.cardHeader}>Répartition par catégories</Text>
+            <View style={styles.cardContent}>
+              <Text style={styles.categoryDescription}>
+                Graphique circulaire présentant la répartition des commentaires
+                par catégorie.
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        {groupedCommentsByPost.map(([postKey, commentList], index) => {
+          const post = posts.find(
+            (p) => `${p.postId}-${p.socialNetwork}` === postKey,
+          );
+          if (!post) return null;
+
+          return (
+            <View key={postKey} style={styles.postSection}>
+              <View style={styles.postSummaryCard}>
+                {post.coverImageUrl && (
+                  <Image
+                    src={post.coverImageUrl}
+                    style={styles.postCoverImage}
+                  />
+                )}
+                <View style={styles.postInfoBlock}>
+                  {post.title && (
+                    <Text style={styles.postTitle}>{post.title}</Text>
+                  )}
+                  <Text style={styles.postMeta}>URL : {post.url}</Text>
+                  <Text style={styles.postMeta}>
+                    Publié le {formatPublicationDate(post.publishedAt)}
+                  </Text>
+                </View>
+              </View>
+
+              <View style={styles.commentsTable}>
+                <View style={styles.tableHeaderRow}>
+                  <Text
+                    style={[styles.tableHeaderCell, styles.colCommentAuthor]}
+                  >
+                    Auteur
+                  </Text>
+                  <Text
+                    style={[
+                      styles.tableHeaderCell,
+                      styles.colCommentScreenshot,
+                    ]}
+                  >
+                    Capture du commentaire
+                  </Text>
+                  <Text style={[styles.tableHeaderCell, styles.colCommentDate]}>
+                    Date
+                  </Text>
+                </View>
+                {commentList?.map((comment) => (
+                  <View key={comment.id} style={styles.tableDataRow}>
+                    <Text style={[styles.tableCell, styles.colCommentAuthor]}>
+                      {comment.author.name}
+                    </Text>
+                    <View style={styles.colCommentScreenshot}>
+                      {comment.screenshotData ? (
+                        <Image
+                          src={buildDataUrl(
+                            comment.screenshotData,
+                            PNG_MIME_TYPE,
+                          )}
+                          style={styles.screenshotImage}
+                        />
+                      ) : (
+                        <Text style={[styles.tableCell, styles.naText]}>
+                          N/A
+                        </Text>
+                      )}
+                    </View>
+                    <Text style={[styles.tableCell, styles.colCommentDate]}>
+                      {formatPublicationDate(comment.publishedAt)}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+
+              <Text style={styles.pagination}>
+                {index + 1}/{reportQueryData.postIdList.length} publications
+              </Text>
+            </View>
+          );
+        })}
+      </Page>
+    </Document>
+  );
+};

--- a/browser-extension/src/entrypoints/posts/Report/PdfReport.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/PdfReport.tsx
@@ -128,7 +128,7 @@ const styles = StyleSheet.create({
   colCommentAuthor: { width: "22%" },
   colCommentScreenshot: { width: "58%" },
   colCommentDate: { width: "20%" },
-  screenshotImage: { maxWidth: "100%", maxHeight: pxToPt(140) },
+  screenshotImage: { maxWidth: "100%" },
   naText: { color: "#9ca3af" },
   pagination: { fontSize: pxToPt(10), color: GRAY_500 },
   categoryDescription: { fontSize: pxToPt(10), lineHeight: 1.4 },

--- a/browser-extension/src/entrypoints/posts/Report/Report.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Report.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router";
-import { MoveLeft, TriangleAlert, UserRound } from "lucide-react";
+import { MoveLeft, TriangleAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   formatAnalysisDate,
@@ -7,26 +7,7 @@ import {
 } from "@/shared/utils/post-util";
 import { ReportQueryData } from "./BuildReport";
 import { SocialNetworkName } from "@/shared/model/SocialNetworkName";
-import KpiCard from "../Shared/KpiCards/KpiCard";
-import React from "react";
-import { useQuery } from "@tanstack/react-query";
-import { getPostsByPostIdList } from "@/shared/storage/post-storage";
-import NumberHatefulAuhorsKpiCard from "../Shared/KpiCards/NumberHatefulAuhorsKpiCard";
-import ActiveAuthors from "../Shared/ActiveAuthors";
-import CategoryDistribution from "../Shared/CategoryDistribution";
-import PercentageHatefulCommentsKpiCard from "../Shared/KpiCards/PercentageHatefulCommentsKpiCard";
-import NumberHatefulCommentsKpiCard from "../Shared/KpiCards/NumberHatefulCommentsKpiCard";
-import PostSummary from "../Shared/PostSummary";
-import { Card } from "@/components/ui/card";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
-import DisplayPublicationDate from "../Developer/DisplayPublicationDate";
+import { useMemo, useState } from "react";
 import { buildDataUrl, PNG_MIME_TYPE } from "@/shared/utils/data-url";
 import {
   Dialog,
@@ -37,20 +18,29 @@ import {
 import { Packer } from "docx";
 import { buildReportCsv } from "./reportCsv";
 import { buildReportDocx } from "./reportDocx";
+import { ReportContent } from "./ReportContent";
+import { useReportPosts } from "@/shared/utils/report-data";
+import { DownloadPdfButton } from "./DownloadPdfButton";
+import { useQuery } from "@tanstack/react-query";
+import { getPostsByPostIdList } from "@/shared/storage/post-storage";
 
-function Report({
+const Report = ({
   reportQueryData,
 }: Readonly<{
   reportQueryData: ReportQueryData | undefined;
-}>) {
-  const [screenshotDialogOpen, setScreenshotDialogOpen] = React.useState(false);
+}>) => {
+  const [screenshotDialogOpen, setScreenshotDialogOpen] = useState(false);
+  const [selectedScreenshot, setSelectedScreenshot] = useState<string | null>(
+    null,
+  );
 
-  const [selectedScreenshot, setSelectedScreenshot] = React.useState<
-    string | null
-  >(null);
+  const { data: posts, isLoading: isLoadingPosts } = useReportPosts(
+    reportQueryData?.postIdList,
+  );
 
-  const queryKey = React.useMemo(
+  const queryKey = useMemo(
     () => ["posts", reportQueryData?.socialNetworkList?.join(",") ?? ""],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [reportQueryData?.socialNetworkList?.join(",")],
   );
 
@@ -58,22 +48,6 @@ function Report({
     queryKey,
     queryFn: () => getPostsByPostIdList(reportQueryData?.postIdList ?? []),
   });
-
-  const numberOfHatefulComments = reportQueryData?.postCommentList?.length ?? 0;
-  const numberOfComments = data?.flatMap((p) => p.comments).length ?? 0;
-
-  const openScreenshotDialog = (screenshot: string) => {
-    setSelectedScreenshot(screenshot);
-    setScreenshotDialogOpen(true);
-  };
-
-  const groupedCommentsByPost = React.useMemo(() => {
-    const comments = reportQueryData?.postCommentList || [];
-
-    return Object.entries(
-      Object.groupBy(comments, (comment) => comment.postKey),
-    );
-  }, [reportQueryData?.postCommentList]);
 
   const canExportCsv =
     !isLoading && (reportQueryData?.postCommentList.length ?? 0) > 0;
@@ -135,9 +109,16 @@ function Report({
           >
             Exporter les données en CSV
           </Button>
-          <Button variant="outline" disabled>
-            Télécharger le PDF
-          </Button>
+          {reportQueryData && posts ? (
+            <DownloadPdfButton
+              reportQueryData={reportQueryData}
+              posts={posts}
+            />
+          ) : (
+            <Button variant="outline" disabled>
+              Télécharger le PDF
+            </Button>
+          )}
           <Button
             variant="outline"
             disabled={!canExportDocx}
@@ -151,8 +132,8 @@ function Report({
         <TriangleAlert className="me-2" />
         <span>
           Ce rapport ne pourra pas être enregistré sur votre navigateur. Pensez
-          à télécharger le rapport en DOCX ou exporter les données du rapport en
-          CSV.
+          à télécharger le rapport en PDF ou en DOCX, ou exporter les données
+          du rapport en CSV.
         </span>
       </div>
       <div className="flex flex-col items-end">
@@ -179,100 +160,15 @@ function Report({
           </span>
         </span>
       </div>
-      <div className="flex flex-col gap-4">
-        <h1 className="text-2xl font-bold">
-          Rapport des commentaires malveillants
-        </h1>
-        <div className="flex">
-          <div className="flex gap-4 justify-between">
-            <NumberHatefulCommentsKpiCard
-              numberOfHatefulComments={numberOfHatefulComments}
-              numberOfComments={numberOfComments}
-              isLoading={isLoading}
-            />
-            <PercentageHatefulCommentsKpiCard
-              numberOfHatefulComments={numberOfHatefulComments}
-              numberOfComments={numberOfComments}
-              isLoading={isLoading}
-            />
-            <NumberHatefulAuhorsKpiCard
-              hatefulCommentList={reportQueryData?.postCommentList ?? []}
-              isLoading={isLoading}
-            />
-            <KpiCard
-              title="Gravité"
-              value="Modérée"
-              isWorkInProgress={true}
-              isLoading={isLoading}
-            ></KpiCard>
-          </div>
-        </div>
-        <div className="flex gap-6">
-          <ActiveAuthors
-            postComments={reportQueryData?.postCommentList ?? []}
-            isLoading={isLoading}
-          />
-          <CategoryDistribution />
-        </div>
-        {groupedCommentsByPost.map(([postKey, commentList], index) => {
-          const post = data?.find(
-            (p) => `${p.postId}-${p.socialNetwork}` === postKey,
-          );
-          if (!post) return null;
-          return (
-            <div key={postKey} className="flex flex-col gap-2">
-              <Card className="p-5">
-                <PostSummary post={post} />
-              </Card>
 
-              <div className="rounded-md border">
-                <Table>
-                  <TableHeader className="bg-gray-200">
-                    <TableRow>
-                      <TableHead>Auteur</TableHead>
-                      <TableHead>Capture du commentaire</TableHead>
-                      <TableHead>Date</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {commentList?.map((comment) => (
-                      <TableRow key={comment.id}>
-                        <TableCell>
-                          <div className="flex gap-2">
-                            <UserRound className="bg-gray-200 rounded-full" />
-                            {comment.author.name}
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <img
-                            src={buildDataUrl(
-                              comment.screenshotData,
-                              PNG_MIME_TYPE,
-                            )}
-                            alt="Capture d'écran du commentaire"
-                            className="cursor-pointer h-full max-h-full!"
-                            onClick={() =>
-                              openScreenshotDialog(comment.screenshotData)
-                            }
-                          />
-                        </TableCell>
-                        <TableCell>
-                          <DisplayPublicationDate date={comment.publishedAt} />
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-              <span className="self-start">
-                {index + 1}/{reportQueryData?.postIdList.length} publications
-              </span>
-            </div>
-          );
-        })}
-      </div>
+      <ReportContent
+        reportQueryData={reportQueryData}
+        posts={posts}
+        isLoadingPosts={isLoadingPosts}
+        setSelectedScreenshot={setSelectedScreenshot}
+        setScreenshotDialogOpen={setScreenshotDialogOpen}
+      />
 
-      {/* Screenshot Dialog */}
       <Dialog
         open={screenshotDialogOpen}
         onOpenChange={setScreenshotDialogOpen}
@@ -292,6 +188,6 @@ function Report({
       </Dialog>
     </>
   );
-}
+};
 
 export default Report;

--- a/browser-extension/src/entrypoints/posts/Report/Report.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Report.tsx
@@ -23,6 +23,7 @@ import { useReportPosts } from "@/shared/utils/report-data";
 import { DownloadPdfButton } from "./DownloadPdfButton";
 import { useQuery } from "@tanstack/react-query";
 import { getPostsByPostIdList } from "@/shared/storage/post-storage";
+import { DOWNLOAD_PDF_LABEL } from "@/shared/constants/labels";
 
 const Report = ({
   reportQueryData,
@@ -40,7 +41,6 @@ const Report = ({
 
   const queryKey = useMemo(
     () => ["posts", reportQueryData?.socialNetworkList?.join(",") ?? ""],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [reportQueryData?.socialNetworkList?.join(",")],
   );
 
@@ -116,7 +116,7 @@ const Report = ({
             />
           ) : (
             <Button variant="outline" disabled>
-              Télécharger le PDF
+              {DOWNLOAD_PDF_LABEL}
             </Button>
           )}
           <Button
@@ -132,8 +132,8 @@ const Report = ({
         <TriangleAlert className="me-2" />
         <span>
           Ce rapport ne pourra pas être enregistré sur votre navigateur. Pensez
-          à télécharger le rapport en PDF ou en DOCX, ou exporter les données
-          du rapport en CSV.
+          à télécharger le rapport en PDF ou en DOCX, ou exporter les données du
+          rapport en CSV.
         </span>
       </div>
       <div className="flex flex-col items-end">

--- a/browser-extension/src/entrypoints/posts/Report/ReportContent.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/ReportContent.tsx
@@ -1,0 +1,148 @@
+import { ReportQueryData } from "./BuildReport";
+import { UserRound } from "lucide-react";
+
+import KpiCard from "../Shared/KpiCards/KpiCard";
+
+import NumberHatefulAuhorsKpiCard from "../Shared/KpiCards/NumberHatefulAuhorsKpiCard";
+import ActiveAuthors from "../Shared/ActiveAuthors";
+import CategoryDistribution from "../Shared/CategoryDistribution";
+import PercentageHatefulCommentsKpiCard from "../Shared/KpiCards/PercentageHatefulCommentsKpiCard";
+import NumberHatefulCommentsKpiCard from "../Shared/KpiCards/NumberHatefulCommentsKpiCard";
+import PostSummary from "../Shared/PostSummary";
+import { Card } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import DisplayPublicationDate from "../Developer/DisplayPublicationDate";
+
+import { buildDataUrl, PNG_MIME_TYPE } from "@/shared/utils/data-url";
+import { Post } from "@/shared/model/post/Post";
+import { getEntriesGroupedByPostKey } from "@/shared/utils/report-data";
+
+interface ReportContentProps {
+  reportQueryData?: ReportQueryData;
+  posts?: Post[];
+  isLoadingPosts: boolean;
+  setSelectedScreenshot: (screenshot: string | null) => void;
+  setScreenshotDialogOpen: (open: boolean) => void;
+}
+
+export const ReportContent = ({
+  reportQueryData,
+  posts,
+  isLoadingPosts,
+  setSelectedScreenshot,
+  setScreenshotDialogOpen,
+}: ReportContentProps) => {
+  const numberOfHatefulComments = reportQueryData?.postCommentList?.length ?? 0;
+  const numberOfComments = posts?.flatMap((post) => post.comments).length ?? 0;
+
+  const openScreenshotDialog = (screenshot: string) => {
+    setSelectedScreenshot(screenshot);
+    setScreenshotDialogOpen(true);
+  };
+
+  const groupedCommentsByPost = getEntriesGroupedByPostKey(
+    reportQueryData?.postCommentList ?? [],
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <h1 className="text-2xl font-bold">
+        Rapport des commentaires malveillants
+      </h1>
+      <div className="flex">
+        <div className="flex gap-4 justify-between">
+          <NumberHatefulCommentsKpiCard
+            numberOfHatefulComments={numberOfHatefulComments}
+            numberOfComments={numberOfComments}
+            isLoading={isLoadingPosts}
+          />
+          <PercentageHatefulCommentsKpiCard
+            numberOfHatefulComments={numberOfHatefulComments}
+            numberOfComments={numberOfComments}
+            isLoading={isLoadingPosts}
+          />
+          <NumberHatefulAuhorsKpiCard
+            hatefulCommentList={reportQueryData?.postCommentList ?? []}
+            isLoading={isLoadingPosts}
+          />
+          <KpiCard
+            title="Gravité"
+            value="Modérée"
+            isWorkInProgress={true}
+            isLoading={isLoadingPosts}
+          />
+        </div>
+      </div>
+      <div className="flex gap-6">
+        <ActiveAuthors
+          postComments={reportQueryData?.postCommentList ?? []}
+          isLoading={isLoadingPosts}
+        />
+        <CategoryDistribution />
+      </div>
+      {groupedCommentsByPost.map(([postKey, commentList], index) => {
+        const post = posts?.find(
+          (p) => `${p.postId}-${p.socialNetwork}` === postKey,
+        );
+        if (!post) return null;
+        return (
+          <div key={postKey} className="flex flex-col gap-2">
+            <Card className="p-5">
+              <PostSummary post={post} />
+            </Card>
+
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader className="bg-gray-200">
+                  <TableRow>
+                    <TableHead>Auteur</TableHead>
+                    <TableHead>Capture du commentaire</TableHead>
+                    <TableHead>Date</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {commentList?.map((comment) => (
+                    <TableRow key={comment.id}>
+                      <TableCell>
+                        <div className="flex gap-2">
+                          <UserRound className="bg-gray-200 rounded-full" />
+                          {comment.author.name}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <img
+                          src={buildDataUrl(
+                            comment.screenshotData,
+                            PNG_MIME_TYPE,
+                          )}
+                          alt="Capture d'écran du commentaire"
+                          className="cursor-pointer h-full max-h-full!"
+                          onClick={() =>
+                            openScreenshotDialog(comment.screenshotData)
+                          }
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <DisplayPublicationDate date={comment.publishedAt} />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+            <span className="self-start">
+              {index + 1}/{reportQueryData?.postIdList.length} publications
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/browser-extension/src/entrypoints/posts/Shared/ActiveAuthors.tsx
+++ b/browser-extension/src/entrypoints/posts/Shared/ActiveAuthors.tsx
@@ -3,15 +3,9 @@ import WorkInProgress from "../WorkInProgress";
 import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { CircleUserRound } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
-import { isCommentHateful } from "@/shared/utils/post-util";
-import { getPercentage } from "@/shared/utils/maths";
 import { PostComment } from "@/shared/model/post/Post";
-
-type AuthorStats = {
-  name: string;
-  numberOfComments: number;
-  numberOfHatefulComments: number;
-};
+import { getAuthorStatsList } from "@/shared/utils/report-stats";
+import { getPercentage } from "@/shared/utils/maths";
 
 type ActiveAuthorsProps = {
   postComments: PostComment[];
@@ -22,36 +16,7 @@ function ActiveAuthors({
   postComments,
   isLoading,
 }: Readonly<ActiveAuthorsProps>) {
-  const authorStatsList = postComments
-    .reduce((authorStatsList: AuthorStats[], currentComment) => {
-      const existingAuthorIndex = authorStatsList.findIndex(
-        (author) => author.name === currentComment.author.name,
-      );
-
-      // Si l'auteur n'est pas encore dans la liste des commentaires les plus récents, on l'ajoute
-      if (existingAuthorIndex === -1) {
-        authorStatsList.push({
-          name: currentComment.author.name,
-          numberOfComments: 1,
-          numberOfHatefulComments: isCommentHateful(currentComment) ? 1 : 0,
-        });
-      } else {
-        // Si l'auteur est déjà dans la liste, on incrémente le nombre de commentaires
-        authorStatsList[existingAuthorIndex].numberOfComments += 1;
-        if (isCommentHateful(currentComment)) {
-          authorStatsList[existingAuthorIndex].numberOfHatefulComments += 1;
-        }
-      }
-      return authorStatsList;
-    }, [])
-    .filter((authorStats) => authorStats.numberOfHatefulComments >= 1) // ne garder que les auteurs avec au moins 1 commentaire haineux;
-    .sort(
-      // trier par ratio de commentaires haineux décroissant
-      (a, b) =>
-        getPercentage(b.numberOfHatefulComments, b.numberOfComments) -
-        getPercentage(a.numberOfHatefulComments, a.numberOfComments),
-    )
-    .slice(0, 6); // Récupérer les 6 auteurs les plus actifs parmi ceux ayant posté au moins un commentaire haineux (en attendant une éventuelle pagination)
+  const authorStatsList = getAuthorStatsList(postComments);
 
   return (
     <Card className="w-full relative">

--- a/browser-extension/src/entrypoints/posts/Shared/KpiCards/NumberHatefulAuhorsKpiCard.tsx
+++ b/browser-extension/src/entrypoints/posts/Shared/KpiCards/NumberHatefulAuhorsKpiCard.tsx
@@ -1,5 +1,6 @@
 import { PostComment } from "@/shared/model/post/Post";
 import KpiCard from "./KpiCard";
+import { getNumberOfHatefulAuthors } from "@/shared/utils/report-stats";
 
 type NumberHatefulAuhorsKpiCardProperties = {
   hatefulCommentList: PostComment[];
@@ -10,9 +11,7 @@ export default function NumberHatefulAuhorsKpiCard({
   hatefulCommentList,
   isLoading,
 }: Readonly<NumberHatefulAuhorsKpiCardProperties>) {
-  const numberOfHatefulAuthors = new Set(
-    hatefulCommentList.map((c) => c.author.name),
-  ).size;
+  const numberOfHatefulAuthors = getNumberOfHatefulAuthors(hatefulCommentList);
 
   return (
     <KpiCard

--- a/browser-extension/src/shared/constants/labels.ts
+++ b/browser-extension/src/shared/constants/labels.ts
@@ -1,0 +1,1 @@
+export const DOWNLOAD_PDF_LABEL = "Télécharger le PDF";

--- a/browser-extension/src/shared/utils/__tests__/report-data.test.ts
+++ b/browser-extension/src/shared/utils/__tests__/report-data.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  getEntriesGroupedByPostKey,
+  getReportPostsQueryKey,
+  REPORT_PDF_FILE_NAME,
+} from "../report-data";
+
+describe("report-data", () => {
+  it("should build a stable query key from selected post ids", () => {
+    expect(getReportPostsQueryKey(["post-1", "post-2"])).toEqual([
+      "report-posts",
+      ["post-1", "post-2"],
+    ]);
+  });
+
+  it("should group comments by post key while preserving insertion order", () => {
+    expect(
+      getEntriesGroupedByPostKey([
+        { id: "1", postKey: "post-a" },
+        { id: "2", postKey: "post-b" },
+        { id: "3", postKey: "post-a" },
+      ]),
+    ).toEqual([
+      [
+        "post-a",
+        [
+          { id: "1", postKey: "post-a" },
+          { id: "3", postKey: "post-a" },
+        ],
+      ],
+      ["post-b", [{ id: "2", postKey: "post-b" }]],
+    ]);
+  });
+
+  it("should expose the expected download file name", () => {
+    expect(REPORT_PDF_FILE_NAME).toBe("rapport-commentaires-malveillants.pdf");
+  });
+});

--- a/browser-extension/src/shared/utils/__tests__/report-stats.test.ts
+++ b/browser-extension/src/shared/utils/__tests__/report-stats.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { PostComment } from "@/shared/model/post/Post";
+import { getAuthorStatsList, getNumberOfHatefulAuthors } from "../report-stats";
+
+const buildComment = (
+  authorName: string,
+  classification?: string[],
+): PostComment => ({
+  textContent: `${authorName} comment`,
+  author: {
+    name: authorName,
+    accountHref: `https://example.com/${authorName.toLowerCase()}`,
+  },
+  publishedAt: {
+    type: "absolute",
+    date: "2026-01-01T00:00:00.000Z",
+  },
+  classification,
+  screenshotData: "SGVsbG8=",
+  isNew: false,
+  isDeleted: false,
+});
+
+describe("report-stats", () => {
+  it("should count unique hateful authors", () => {
+    expect(
+      getNumberOfHatefulAuthors([
+        buildComment("Alice", ["Cyberharcèlement (autre)"]),
+        buildComment("Alice", ["Cyberharcèlement (autre)"]),
+        buildComment("Bob", ["Cyberharcèlement (autre)"]),
+      ]),
+    ).toBe(2);
+  });
+
+  it("should build sorted author stats limited to hateful authors", () => {
+    expect(
+      getAuthorStatsList([
+        buildComment("Alice", ["Cyberharcèlement (autre)"]),
+        buildComment("Alice", ["Neutre"]),
+        buildComment("Bob", ["Cyberharcèlement (autre)"]),
+        buildComment("Claire", ["Neutre"]),
+      ]),
+    ).toEqual([
+      {
+        name: "Bob",
+        numberOfComments: 1,
+        numberOfHatefulComments: 1,
+      },
+      {
+        name: "Alice",
+        numberOfComments: 2,
+        numberOfHatefulComments: 1,
+      },
+    ]);
+  });
+});

--- a/browser-extension/src/shared/utils/report-data.ts
+++ b/browser-extension/src/shared/utils/report-data.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import { getPostsByPostIdList } from "@/shared/storage/post-storage";
+
+export const REPORT_PDF_FILE_NAME = "rapport-commentaires-malveillants.pdf";
+
+type HasPostKey = {
+  postKey: string;
+};
+
+export const getEntriesGroupedByPostKey = <T extends HasPostKey>(
+  items: readonly T[],
+) => Object.entries(Object.groupBy(items, (item) => item.postKey));
+
+export const getReportPostsQueryKey = (postIdList?: readonly string[]) =>
+  ["report-posts", postIdList ?? []] as const;
+
+export const useReportPosts = (postIdList?: readonly string[]) =>
+  useQuery({
+    queryKey: getReportPostsQueryKey(postIdList),
+    queryFn: () => getPostsByPostIdList([...(postIdList ?? [])]),
+    enabled: Boolean(postIdList?.length),
+  });

--- a/browser-extension/src/shared/utils/report-stats.ts
+++ b/browser-extension/src/shared/utils/report-stats.ts
@@ -45,7 +45,7 @@ export const getAuthorStatsList = (
       (a, b) =>
         getPercentage(b.numberOfHatefulComments, b.numberOfComments) -
         getPercentage(a.numberOfHatefulComments, a.numberOfComments),
-      )
+    )
     .slice(0, ACTIVE_AUTHORS_LIMIT); // Récupérer les 6 auteurs les plus actifs parmi ceux ayant posté au moins un commentaire haineux (en attendant une éventuelle pagination)
 
   return authorStatsList;

--- a/browser-extension/src/shared/utils/report-stats.ts
+++ b/browser-extension/src/shared/utils/report-stats.ts
@@ -1,0 +1,52 @@
+import { getPercentage } from "@/shared/utils/maths";
+import { PostComment } from "@/shared/model/post/Post";
+import { isCommentHateful } from "@/shared/utils/post-util";
+
+export type AuthorStats = {
+  name: string;
+  numberOfComments: number;
+  numberOfHatefulComments: number;
+};
+
+const ACTIVE_AUTHORS_LIMIT = 6;
+
+export const getNumberOfHatefulAuthors = (
+  hatefulCommentList: readonly PostComment[],
+) => new Set(hatefulCommentList.map((comment) => comment.author.name)).size;
+
+export const getAuthorStatsList = (
+  postComments: readonly PostComment[],
+): AuthorStats[] => {
+  const authorStatsList = postComments
+    .reduce((authorStatsList: AuthorStats[], currentComment) => {
+      const existingAuthorIndex = authorStatsList.findIndex(
+        (author) => author.name === currentComment.author.name,
+      );
+
+      // Si l'auteur n'est pas encore dans la liste des commentaires les plus récents, on l'ajoute
+      if (existingAuthorIndex === -1) {
+        authorStatsList.push({
+          name: currentComment.author.name,
+          numberOfComments: 1,
+          numberOfHatefulComments: isCommentHateful(currentComment) ? 1 : 0,
+        });
+      } else {
+        // Si l'auteur est déjà dans la liste, on incrémente le nombre de commentaires
+        authorStatsList[existingAuthorIndex].numberOfComments += 1;
+        if (isCommentHateful(currentComment)) {
+          authorStatsList[existingAuthorIndex].numberOfHatefulComments += 1;
+        }
+      }
+      return authorStatsList;
+    }, [])
+    .filter((authorStats) => authorStats.numberOfHatefulComments >= 1) // ne garder que les auteurs avec au moins 1 commentaire haineux;
+    .sort(
+      // trier par ratio de commentaires haineux décroissant
+      (a, b) =>
+        getPercentage(b.numberOfHatefulComments, b.numberOfComments) -
+        getPercentage(a.numberOfHatefulComments, a.numberOfComments),
+      )
+    .slice(0, ACTIVE_AUTHORS_LIMIT); // Récupérer les 6 auteurs les plus actifs parmi ceux ayant posté au moins un commentaire haineux (en attendant une éventuelle pagination)
+
+  return authorStatsList;
+};


### PR DESCRIPTION
﻿ ## Résumé
 
 Cette PR ajoute l’export **PDF** du rapport des commentaires malveillants depuis l’extension navigateur.
 
 L’objectif est de permettre aux utilisateurs de télécharger une version exploitable et partageable du rapport, en reprenant les informations clés déjà visibles dans l’interface.
 
 ## Changements
 
 - activation du bouton **Télécharger le PDF** dans l’écran de rapport
 - génération d’un document PDF avec `@react-pdf/renderer`
 - ajout d’un composant dédié `PdfReport` pour structurer le contenu exporté
 - extraction d’un `ReportContent` partagé pour clarifier la séparation entre affichage UI et logique de données
 - mutualisation de la récupération des posts et du regroupement des commentaires par publication
 - extraction des statistiques auteurs/commentaires dans des utilitaires dédiés
 - ajout de tests unitaires pour sécuriser les helpers de données du rapport
 
 ## Notes
 
 - la dépendance `@react-pdf/renderer` a été ajoutée pour supporter la génération du document
 - la structure du rapport a été refactorée pour faciliter les futurs exports et évolutions
 
 close #250