### PR TITLE
[Front] ajustements UI (vue d'ensemble et détail publication) pour aligner sur les maquettes

### DIFF
--- a/browser-extension/src/components/ui/chart.tsx
+++ b/browser-extension/src/components/ui/chart.tsx
@@ -163,7 +163,7 @@ function ChartTooltipContent({
 
     if (labelFormatter) {
       return (
-        <div className={cn("font-medium", labelClassName)}>
+        <div className={cn("font-bold", labelClassName)}>
           {labelFormatter(value, payload)}
         </div>
       );
@@ -173,7 +173,7 @@ function ChartTooltipContent({
       return null;
     }
 
-    return <div className={cn("font-medium", labelClassName)}>{value}</div>;
+    return <div className={cn("font-bold", labelClassName)}>{value}</div>;
   }, [
     label,
     labelFormatter,
@@ -193,7 +193,7 @@ function ChartTooltipContent({
   return (
     <div
       className={cn(
-        "grid min-w-32 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+        "grid min-w-32 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl text-left",
         className,
       )}
     >
@@ -244,7 +244,7 @@ function ChartTooltipContent({
                     )}
                     <div
                       className={cn(
-                        "flex flex-1 justify-between leading-none",
+                        "flex flex-1 justify-between leading-none gap-1",
                         nestLabel ? "items-end" : "items-center",
                       )}
                     >
@@ -255,7 +255,7 @@ function ChartTooltipContent({
                         </span>
                       </div>
                       {item.value != null && (
-                        <span className="font-mono font-medium text-foreground tabular-nums">
+                        <span className="font-bold text-foreground tabular-nums">
                           {typeof item.value === "number"
                             ? item.value.toLocaleString()
                             : String(item.value)}

--- a/browser-extension/src/entrypoints/posts/Home/HarassmentTrendChard.tsx
+++ b/browser-extension/src/entrypoints/posts/Home/HarassmentTrendChard.tsx
@@ -190,14 +190,7 @@ function HarassmentTrendChart({
             <YAxis />
             <ChartLegend content={<ChartLegendContent />} />
             <Bar dataKey="nombre" fill="var(--primary)" radius={4} />
-            <ChartTooltip
-              content={
-                <ChartTooltipContent
-                  indicator="line"
-                  className="max-w-1/12 text-left "
-                />
-              }
-            />
+            <ChartTooltip content={<ChartTooltipContent indicator="line" />} />
           </BarChart>
         </ChartContainer>
       </CardContent>

--- a/browser-extension/src/entrypoints/posts/Home/HomePage.tsx
+++ b/browser-extension/src/entrypoints/posts/Home/HomePage.tsx
@@ -27,7 +27,7 @@ function HomePage() {
     dateRange?.to?.toISOString() ?? "",
   ];
 
-  const { data, isLoading } = useQuery({
+  const { data: posts, isLoading } = useQuery({
     queryKey,
     queryFn: () =>
       getPostsBySocialNetworkAndPeriod(
@@ -37,18 +37,25 @@ function HomePage() {
       ),
   });
 
-  const allComments = (data || []).flatMap((p) => p.comments);
+  const allComments = (posts || []).flatMap((p) => p.comments);
 
   return (
     <main className="flex flex-col gap-6">
       <PageHeader title="Vue d'ensemble" />
-      <div className="flex justify-between ">
+      <div className="flex align-start">
         <SocialNetworkSelector
           value={socialNetworkFilter}
           onChange={setSocialNetworkFilter}
         />
+      </div>
+      <div className="flex justify-between">
+        <div className="text-muted-foreground text-sm my-auto">
+          Publications analysées pour la période sélectionnée :{" "}
+          <span className="font-bold">{posts?.length}</span>
+        </div>
+
         <DateRangePicker
-          startDate={dateRange?.from || getEarliestPostDate(data)}
+          startDate={dateRange?.from || getEarliestPostDate(posts)}
           onChange={setDateRange}
         />
       </div>
@@ -57,7 +64,7 @@ function HomePage() {
 
       {allComments.length > 0 && (
         <>
-          <KpiCards posts={data} isLoading={isLoading} />
+          <KpiCards posts={posts} isLoading={isLoading} />
           <HarassmentTrendChart
             dateRange={dateRange}
             commentList={allComments}

--- a/browser-extension/src/entrypoints/posts/Posts/PostDetailPage.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/PostDetailPage.tsx
@@ -94,21 +94,21 @@ function PostDetailPage() {
             </Card>
             <div className="flex flex-col gap-3">
               <div className="flex gap-4 justify-between w-full">
-                <NumberHatefulCommentsKpiCard
-                  numberOfHatefulComments={numberOfHatefulComments}
-                  numberOfComments={allComments.length}
-                  isLoading={isLoading}
-                />
                 <PercentageHatefulCommentsKpiCard
                   numberOfHatefulComments={numberOfHatefulComments}
                   numberOfComments={allComments.length}
                   isLoading={isLoading}
                 />
+                <NumberHatefulCommentsKpiCard
+                  numberOfHatefulComments={numberOfHatefulComments}
+                  numberOfComments={allComments.length}
+                  isLoading={isLoading}
+                />
+                <SecurityAlert isLoading={isLoading}></SecurityAlert>
                 <NumberHatefulAuhorsKpiCard
                   hatefulCommentList={hatefulComments}
                   isLoading={isLoading}
                 />
-                <SecurityAlert isLoading={isLoading}></SecurityAlert>
               </div>
               <div className="flex gap-4 w-full">
                 <ActiveAuthors

--- a/browser-extension/src/entrypoints/posts/Shared/ActiveAuthors.tsx
+++ b/browser-extension/src/entrypoints/posts/Shared/ActiveAuthors.tsx
@@ -94,12 +94,7 @@ function ActiveAuthors({
                 />
               </Bar>
               <ChartTooltip
-                content={
-                  <ChartTooltipContent
-                    indicator="line"
-                    className="max-w-1/12 text-left "
-                  />
-                }
+                content={<ChartTooltipContent indicator="line" />}
               />
             </BarChart>
           </ChartContainer>

--- a/browser-extension/src/entrypoints/posts/Shared/CategoryDistribution.tsx
+++ b/browser-extension/src/entrypoints/posts/Shared/CategoryDistribution.tsx
@@ -50,10 +50,17 @@ function CategoryDistribution({
     fill: CATEGORY_COLORS[i % CATEGORY_COLORS.length],
   }));
 
-  const chartConfig = dataPoints.reduce<ChartConfig>((acc, d) => {
-    acc[d.name] = { label: d.name, color: d.fill };
-    return acc;
-  }, {}) satisfies ChartConfig;
+  const chartConfig = dataPoints.reduce<ChartConfig>(
+    (acc, d) => {
+      acc[d.name] = { label: d.name, color: d.fill };
+      return acc;
+    },
+    {
+      commentsCount: {
+        label: "Commentaires malveillants",
+      },
+    },
+  ) satisfies ChartConfig;
 
   return (
     <Card className="w-full relative self-start">
@@ -99,39 +106,23 @@ function CategoryDistribution({
                   content={
                     <ChartTooltipContent
                       indicator="line"
-                      formatter={(value, _name, item) => (
-                        <>
-                          <div
-                            className="w-1 shrink-0 self-stretch rounded-[2px]"
-                            style={{
-                              backgroundColor: (
-                                item.payload as Record<string, unknown>
-                              ).fill as string,
-                            }}
-                          />
-                          <div className="flex flex-1 justify-between gap-2 leading-none">
-                            <span className="text-muted-foreground">
-                              Commentaires malveillants
-                            </span>
-                            <span className="font-mono font-medium tabular-nums">
-                              {total > 0
-                                ? `${((Number(value) / total) * 100).toLocaleString("fr-FR", { minimumFractionDigits: 1, maximumFractionDigits: 1 })} %`
-                                : "0 %"}
-                            </span>
-                          </div>
-                        </>
-                      )}
+                      labelKey="name"
+                      nameKey="commentsCount"
+                      className="text-left"
                     />
                   }
                 />
               </PieChart>
             </ChartContainer>
 
-            <ul className="flex flex-col gap-1.5 text-xs min-w-0">
+            <ul className="flex flex-col gap-1.5 text-xs min-w-0 ">
               {dataPoints.map((d) => (
-                <li key={d.name} className="flex items-start gap-2">
+                <li
+                  key={d.name}
+                  className="flex flex-row items-center gap-2 text-left"
+                >
                   <div
-                    className="size-2 mt-0.5 shrink-0 rounded-full"
+                    className="size-2 shrink-0 rounded-full "
                     style={{ backgroundColor: d.fill }}
                   />
                   <span className="flex-1 text-muted-foreground">{d.name}</span>


### PR DESCRIPTION
* Charts: aligne les tooltip des charts sur les derniers changements
* Vue d'ensemble: affiche le nombre de publications correspondant à la période
* Détail publication: aligne l'ordre des cartes