### PR TITLE
[Front] fix(report): Fix PDF generation in production build

### DIFF
--- a/browser-extension/wxt.config.ts
+++ b/browser-extension/wxt.config.ts
@@ -49,5 +49,9 @@ export default defineConfig({
       // <all_urls> required for captureVisibleTab when scrap started outside of "activeTab" scope that is from "Relance analyse"
       "<all_urls>",
     ],
+    content_security_policy: {
+      extension_pages:
+        "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';",
+    },
   },
 });


### PR DESCRIPTION
CSP 'wasm-unsafe-eval' is required by react-pdf

Fixes: #334