### PR TITLE
[Front] 306/342/319/159 Mise à jour du wizard et création du rapport à partir des pages des publications

### DIFF
--- a/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
@@ -16,7 +16,7 @@ import {
 import {
   ArrowDownUp,
   Eye,
-  EyeClosed,
+  EyeOff,
   Funnel,
   SearchIcon,
   UserRound,
@@ -216,7 +216,7 @@ export default function CommentsTable({
               {visibleComments.size === filteredComments.length ? (
                 <Eye />
               ) : (
-                <EyeClosed />
+                <EyeOff />
               )}
             </Button>
           </div>
@@ -226,7 +226,7 @@ export default function CommentsTable({
             variant="ghost"
             onClick={() => toggleCommentVisibility(row.id)}
           >
-            {visibleComments.has(row.id) ? <Eye /> : <EyeClosed />}
+            {visibleComments.has(row.id) ? <Eye /> : <EyeOff />}
           </Button>
         ),
       },

--- a/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
@@ -150,7 +150,7 @@ export default function CommentsTable({
           <Checkbox
             className="ms-3 me-5"
             checked={selectedCommentIdList.size === filteredComments.length}
-            onClick={() => setAllCommentsSelection()}
+            onClick={() => setAllCommentsSelection(true)}
           />
         ),
         cell: ({ row }) => (
@@ -310,8 +310,8 @@ export default function CommentsTable({
     }
   };
 
-  const setAllCommentsSelection = () => {
-    if (selectedCommentIdList.size === filteredComments.length) {
+  const setAllCommentsSelection = (canDeselect: boolean) => {
+    if (canDeselect && selectedCommentIdList.size === filteredComments.length) {
       updateSelectedCommentList(new Set());
     } else {
       const allVisibleRowIds = new Set(
@@ -332,8 +332,29 @@ export default function CommentsTable({
           void form.handleSubmit();
         }}
       >
-        <div className="p-3 flex justify-between">
-          <InputGroup className="mx-4 w-1/3">
+        {selectedCommentIdList.size > 0 && (
+          <div className="px-3 pt-2">
+            <div className="pe-2 w-fit gap-1 bg-muted rounded-md flex items-center justify-start font-semibold ">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => {
+                  updateSelectedCommentList(new Set());
+                }}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="Déselectionner tous les commentaires"
+              >
+                ✕
+              </Button>
+              <span className="text-sm">
+                {selectedCommentIdList.size} sélectionné
+                {selectedCommentIdList.size > 1 ? "s" : ""}
+              </span>
+            </div>
+          </div>
+        )}
+        <div className="p-3 flex gap-4">
+          <InputGroup className=" w-1/3">
             <InputGroupInput
               value={inputValue}
               onChange={(event) => setInputValue(event.target.value)}
@@ -343,17 +364,18 @@ export default function CommentsTable({
               <SearchIcon />
             </InputGroupAddon>
           </InputGroup>
-          <div className="flex gap-4">
-            <Button variant="outline" disabled>
-              Tout sélectionner
-            </Button>
-            <Button variant="outline" disabled>
-              Filtrer <Funnel />
-            </Button>
-            <Button variant="outline" disabled>
-              Trier <ArrowDownUp />
-            </Button>{" "}
-          </div>
+          <Button
+            variant="outline"
+            onClick={() => setAllCommentsSelection(false)}
+          >
+            Tout sélectionner
+          </Button>
+          <Button variant="outline" disabled>
+            Filtrer <Funnel />
+          </Button>
+          <Button variant="outline" disabled>
+            Trier <ArrowDownUp />
+          </Button>
         </div>
         <form.Field
           name="commentIdList"

--- a/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
@@ -418,7 +418,7 @@ export default function CommentsTable({
                 </div>
               )}
               <Table className="w-full table-fixed">
-                <TableHeader className="bg-gray-200">
+                <TableHeader className="bg-indigo-brand-100">
                   {table.getHeaderGroups().map((headerGroup) => (
                     <TableRow key={headerGroup.id}>
                       {headerGroup.headers.map((header) => (

--- a/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
@@ -56,6 +56,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { buildDataUrl, PNG_MIME_TYPE } from "@/shared/utils/data-url";
+import { useNavigate } from "react-router";
 
 /**
  * Merged view of Post Snapshot
@@ -70,12 +71,14 @@ export default function CommentsTable({
   defaultSelectedCommentIdList,
   onSubmit,
   formId,
+  showCreateReportButton,
   showScreenshotColumn = false,
 }: Readonly<{
   commentList: PostCommentWithId[];
   defaultSelectedCommentIdList: string[];
   onSubmit: (commentIdList: string[]) => void;
   formId: string;
+  showCreateReportButton: boolean;
   showScreenshotColumn?: boolean;
 }>) {
   const [inputValue, setInputValue] = React.useState("");
@@ -321,6 +324,8 @@ export default function CommentsTable({
     }
   };
 
+  const navigate = useNavigate();
+
   return (
     <>
       <form
@@ -364,6 +369,25 @@ export default function CommentsTable({
               <SearchIcon />
             </InputGroupAddon>
           </InputGroup>
+          {showCreateReportButton && (
+            <Button
+              disabled={selectedCommentIdList.size === 0}
+              onClick={() => {
+                void navigate("/build-report", {
+                  state: {
+                    socialNetworkFilter: commentList[0].postKey.split("-")[1],
+                    selectedPostIds: [commentList[0].postKey.split("-")[0]],
+                    selectedCommentList: commentList.filter((comment) =>
+                      selectedCommentIdList.has(comment.id),
+                    ),
+                    skipToStep: "step-4",
+                  },
+                });
+              }}
+            >
+              Créer un rapport
+            </Button>
+          )}
           <Button
             variant="outline"
             onClick={() => setAllCommentsSelection(false)}

--- a/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
@@ -375,8 +375,8 @@ export default function CommentsTable({
               onClick={() => {
                 void navigate("/build-report", {
                   state: {
-                    socialNetworkFilter: commentList[0].postKey.split("-")[1],
-                    selectedPostIds: [commentList[0].postKey.split("-")[0]],
+                    socialNetworkFilter: [commentList[0].postKey.split("|")[1]],
+                    selectedPostIds: [commentList[0].postKey.split("|")[0]],
                     selectedCommentList: commentList.filter((comment) =>
                       selectedCommentIdList.has(comment.id),
                     ),

--- a/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
@@ -439,7 +439,12 @@ export default function CommentsTable({
                 </TableHeader>
                 <TableBody>
                   {table.getRowModel().rows.map((row) => (
-                    <TableRow key={row.id}>
+                    <TableRow
+                      key={row.id}
+                      className={
+                        selectedCommentIdList.has(row.id) ? "bg-accent-2" : ""
+                      }
+                    >
                       {row.getVisibleCells().map((cell) => (
                         <TableCell key={cell.id}>
                           {flexRender(

--- a/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/CommentsTable.tsx
@@ -64,6 +64,7 @@ import { useNavigate } from "react-router";
 export type PostCommentWithId = PostComment & {
   id: string;
   postKey: string;
+  socialNetwork: string;
 };
 
 export default function CommentsTable({
@@ -375,7 +376,7 @@ export default function CommentsTable({
               onClick={() => {
                 void navigate("/build-report", {
                   state: {
-                    socialNetworkFilter: [commentList[0].postKey.split("|")[1]],
+                    socialNetworkFilter: [commentList[0].socialNetwork],
                     selectedPostIds: [commentList[0].postKey.split("|")[0]],
                     selectedCommentList: commentList.filter((comment) =>
                       selectedCommentIdList.has(comment.id),

--- a/browser-extension/src/entrypoints/posts/Posts/PostDetailPage.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/PostDetailPage.tsx
@@ -6,7 +6,11 @@ import { useQuery } from "@tanstack/react-query";
 import { MoveLeft, RotateCwIcon } from "lucide-react";
 import { Link, useParams } from "react-router";
 import PostSummary from "../Shared/PostSummary";
-import { formatAnalysisDate, isCommentHateful } from "@/shared/utils/post-util";
+import {
+  formatAnalysisDate,
+  isCommentHateful,
+  buildPostKey,
+} from "@/shared/utils/post-util";
 import ActiveAuthors from "../Shared/ActiveAuthors";
 import CategoryDistribution from "../Shared/CategoryDistribution";
 import CommentsTable, { PostCommentWithId } from "./CommentsTable";
@@ -28,15 +32,18 @@ function PostDetailPage() {
   });
 
   const allComments = post?.comments || [];
-  const hatefulComments = allComments
-    .filter((c) => isCommentHateful(c))
-    .map((comment, i) => {
-      return {
-        ...comment,
-        id: i.toString(),
-        postKey: `${post?.postId}|${post?.socialNetwork}`,
-      } as PostCommentWithId;
-    });
+  const hatefulComments = post
+    ? allComments
+        .filter((c) => isCommentHateful(c))
+        .map((comment, i) => {
+          return {
+            ...comment,
+            id: i.toString(),
+            postKey: buildPostKey(post.postId, post.socialNetwork),
+            socialNetwork: post?.socialNetwork,
+          } as PostCommentWithId;
+        })
+    : [];
 
   const numberOfHatefulComments = hatefulComments.length;
 

--- a/browser-extension/src/entrypoints/posts/Posts/PostDetailPage.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/PostDetailPage.tsx
@@ -134,6 +134,7 @@ function PostDetailPage() {
                 defaultSelectedCommentIdList={[]}
                 formId=""
                 onSubmit={() => console.log("submitted")}
+                showCreateReportButton={true}
               />
             </div>
           </div>

--- a/browser-extension/src/entrypoints/posts/Posts/PostDetailPage.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/PostDetailPage.tsx
@@ -34,7 +34,7 @@ function PostDetailPage() {
       return {
         ...comment,
         id: i.toString(),
-        postKey: `${post?.postId}-${post?.socialNetwork}`,
+        postKey: `${post?.postId}|${post?.socialNetwork}`,
       } as PostCommentWithId;
     });
 

--- a/browser-extension/src/entrypoints/posts/Posts/PostListPage.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/PostListPage.tsx
@@ -72,7 +72,7 @@ function PostListPage() {
                 state: {
                   selectedPostIds,
                   socialNetworkFilter,
-                  skipToStep3: true,
+                  skipToStep: "step-3",
                 },
               });
             }}

--- a/browser-extension/src/entrypoints/posts/Posts/PostListPage.tsx
+++ b/browser-extension/src/entrypoints/posts/Posts/PostListPage.tsx
@@ -4,7 +4,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Link } from "react-router";
+import { Link, useNavigate } from "react-router";
 import PostSummary from "../Shared/PostSummary";
 import SearchSortFiltersPostList from "../Shared/SearchSortFiltersPostList";
 import { SocialNetwork } from "@/shared/model/SocialNetworkName";
@@ -25,7 +25,7 @@ function PostListPage() {
   >([SocialNetwork.YouTube]);
   const [postSortingCategory, setPostSortingCategory] =
     React.useState<PostSortingCategory>(PostSortingCategory.ANALYSIS_DATE_DESC);
-
+  const [selectedPostIds, setSelectedPostIds] = React.useState<string[]>([]);
   const {
     searchTerm,
     setSearchTerm,
@@ -36,6 +36,8 @@ function PostListPage() {
     deletePost,
   } = useFilteredPostList(socialNetworkFilter, postSortingCategory);
 
+  const navigate = useNavigate();
+
   return (
     <main className="flex flex-col gap-6  items-start">
       <PageHeader title="Publications analysées" />
@@ -43,6 +45,43 @@ function PostListPage() {
         value={socialNetworkFilter}
         onChange={setSocialNetworkFilter}
       />
+
+      {selectedPostIds.length > 0 && (
+        <div className="flex gap-3 justify-start  w-full">
+          <div className="mb-3 pe-2 w-fit gap-1 bg-muted rounded-md flex items-center justify-start font-semibold ">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                setSelectedPostIds([]);
+              }}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="Déselectionner toutes les publications"
+            >
+              ✕
+            </Button>
+            <span className="text-sm">
+              {selectedPostIds.length} sélectionné
+              {selectedPostIds.length > 1 ? "s" : ""}
+            </span>
+          </div>
+
+          <Button
+            onClick={() => {
+              void navigate("/build-report", {
+                state: {
+                  selectedPostIds,
+                  socialNetworkFilter,
+                  skipToStep3: true,
+                },
+              });
+            }}
+          >
+            Créer un rapport
+          </Button>
+        </div>
+      )}
+
       <SearchSortFiltersPostList
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
@@ -50,6 +89,9 @@ function PostListPage() {
         setPostFilters={setPostFilters}
         postSortingCategory={postSortingCategory}
         setPostSortingCategory={setPostSortingCategory}
+        selectAll={() => {
+          setSelectedPostIds(filteredPosts.map((post) => post.postId));
+        }}
       />
 
       {isLoading && <Spinner className="size-8" />}
@@ -61,62 +103,79 @@ function PostListPage() {
         {filteredPosts &&
           filteredPosts.length > 0 &&
           filteredPosts.map((post) => (
-            <Card key={post.postId} className="w-full">
-              <CardContent className="flex items-center gap-5">
-                <Checkbox className="mr-2" />
-                <div className="w-full">
-                  <PostSummary post={post} />
-                  <div
-                    className={cn(
-                      "mt-2 rounded-2xl flex flex-row px-6 py-2 items-center justify-between border",
-                      post.latestAnalysisStatus === "COMPLETED"
-                        ? "bg-navigation-accent/50 "
-                        : "bg-muted",
-                    )}
-                  >
-                    <div className="text-sm font-medium">
-                      Analyse du {formatAnalysisDate(post.latestAnalysisDate)}
-                    </div>
-                    <div>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        disabled={post.latestAnalysisStatus !== "COMPLETED"}
-                        onClick={() => {
-                          void deletePost(post);
-                        }}
-                      >
-                        <Trash2Icon /> Supprimer
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        disabled={post.latestAnalysisStatus !== "COMPLETED"}
-                        onClick={() => {
-                          void openPostAndStartScraping(post.url);
-                        }}
-                      >
-                        <RotateCwIcon /> Relancer l&apos;analyse
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        disabled={post.latestAnalysisStatus !== "COMPLETED"}
-                        render={
-                          <Link
-                            to={
-                              "/posts/" + post.socialNetwork + "/" + post.postId
-                            }
-                          >
-                            <EyeIcon /> Consulter
-                          </Link>
-                        }
-                      ></Button>
+            <label key={post.postId} className="w-full">
+              <Card key={post.postId}>
+                <CardContent className="flex items-center gap-5">
+                  <Checkbox
+                    className="mr-2"
+                    checked={selectedPostIds.includes(post.postId)}
+                    onCheckedChange={(checked) => {
+                      if (checked) {
+                        setSelectedPostIds([...selectedPostIds, post.postId]);
+                      } else {
+                        setSelectedPostIds(
+                          selectedPostIds.filter((id) => id !== post.postId),
+                        );
+                      }
+                    }}
+                  />
+                  <div className="w-full">
+                    <PostSummary post={post} />
+                    <div
+                      className={cn(
+                        "mt-2 rounded-2xl flex flex-row px-6 py-2 items-center justify-between border",
+                        post.latestAnalysisStatus === "COMPLETED"
+                          ? "bg-navigation-accent/50 "
+                          : "bg-muted",
+                      )}
+                    >
+                      <div className="text-sm font-medium">
+                        Analyse du {formatAnalysisDate(post.latestAnalysisDate)}
+                      </div>
+                      <div>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={post.latestAnalysisStatus !== "COMPLETED"}
+                          onClick={() => {
+                            void deletePost(post);
+                          }}
+                        >
+                          <Trash2Icon /> Supprimer
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={post.latestAnalysisStatus !== "COMPLETED"}
+                          onClick={() => {
+                            void openPostAndStartScraping(post.url);
+                          }}
+                        >
+                          <RotateCwIcon /> Relancer l&apos;analyse
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          disabled={post.latestAnalysisStatus !== "COMPLETED"}
+                          render={
+                            <Link
+                              to={
+                                "/posts/" +
+                                post.socialNetwork +
+                                "/" +
+                                post.postId
+                              }
+                            >
+                              <EyeIcon /> Consulter
+                            </Link>
+                          }
+                        ></Button>
+                      </div>
                     </div>
                   </div>
-                </div>
-              </CardContent>
-            </Card>
+                </CardContent>
+              </Card>
+            </label>
           ))}
       </div>
     </main>

--- a/browser-extension/src/entrypoints/posts/Report/BuildReport.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/BuildReport.tsx
@@ -9,7 +9,7 @@ import Step4Organization from "./Step4Organization";
 import { StepperActions, StepperBanner } from "./StepperComponents";
 import Report from "./Report";
 import { FilePen, XIcon } from "lucide-react";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import { Button } from "@/components/ui/button";
 
 export enum ReportOrganizationType {
@@ -173,7 +173,29 @@ const StepContent = ({
   setDisplayReport: (displayReport: boolean) => void;
   reportQueryData: ReportQueryData | undefined;
 }) => {
+  const location = useLocation();
+
+  const stateFromPostList = location.state as {
+    selectedPostIds?: string[];
+    socialNetworkFilter?: string[];
+    skipToStep3?: boolean;
+  };
+
   const stepper = useStepper();
+  React.useEffect(() => {
+    // If we come from the post list page with selected posts, we want to prefill the stepper with
+    // the selected posts and go to the step 3 (comments) directly
+    if (stateFromPostList?.skipToStep3) {
+      setSocialNetworkList(stateFromPostList.socialNetworkFilter || []);
+      setPostIdList(stateFromPostList.selectedPostIds || []);
+      setCommentList([]);
+      setReportOrganizationType(DEFAULT_REPORT_ORGANIZATION_TYPE);
+      void stepper.navigation.goTo(
+        stateFromPostList?.skipToStep3 ? "step-3" : "step-1",
+      );
+    }
+  }, [stateFromPostList]);
+
   return (
     <div className="pt-4">
       {stepper.flow.when("step-1", () => (

--- a/browser-extension/src/entrypoints/posts/Report/BuildReport.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/BuildReport.tsx
@@ -176,23 +176,22 @@ const StepContent = ({
   const location = useLocation();
 
   const stateFromPostList = location.state as {
-    selectedPostIds?: string[];
     socialNetworkFilter?: string[];
-    skipToStep3?: boolean;
+    selectedPostIds?: string[];
+    selectedCommentList?: PostCommentWithId[];
+    skipToStep?: "step-3" | "step-4";
   };
 
   const stepper = useStepper();
   React.useEffect(() => {
     // If we come from the post list page with selected posts, we want to prefill the stepper with
     // the selected posts and go to the step 3 (comments) directly
-    if (stateFromPostList?.skipToStep3) {
+    if (stateFromPostList?.skipToStep !== undefined) {
       setSocialNetworkList(stateFromPostList.socialNetworkFilter || []);
       setPostIdList(stateFromPostList.selectedPostIds || []);
-      setCommentList([]);
+      setCommentList(stateFromPostList.selectedCommentList || []);
       setReportOrganizationType(DEFAULT_REPORT_ORGANIZATION_TYPE);
-      void stepper.navigation.goTo(
-        stateFromPostList?.skipToStep3 ? "step-3" : "step-1",
-      );
+      void stepper.navigation.goTo(stateFromPostList.skipToStep);
     }
   }, [stateFromPostList]);
 

--- a/browser-extension/src/entrypoints/posts/Report/ReportGroupingUtils.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/ReportGroupingUtils.tsx
@@ -3,6 +3,7 @@ import { Post } from "@/shared/model/post/Post";
 import { PublicationDate } from "@/shared/model/PublicationDate";
 import React from "react";
 import { ReportOrganizationType } from "./BuildReport";
+import { buildPostKey } from "@/shared/utils/post-util";
 
 export interface GroupedData {
   groupKey: string;
@@ -62,9 +63,10 @@ export const getPublicationGroups = (
   comments: PostCommentWithId[],
 ): GroupedData[] => {
   return Array.from(posts ?? []).map((post) => ({
-    groupKey: post.postId + "-" + post.socialNetwork,
+    groupKey: buildPostKey(post.postId, post.socialNetwork),
     comments: comments.filter(
-      (comment) => comment.postKey === post.postId + "-" + post.socialNetwork,
+      (comment) =>
+        comment.postKey === buildPostKey(post.postId, post.socialNetwork),
     ),
     headerContent: createPublicationHeader(post),
     postLatestAnalysisDate: new Date(post.latestAnalysisDate),
@@ -91,7 +93,7 @@ export const getAuthorGroups = (
     // Map comment to its post for later retrieval
     if (posts) {
       const post = posts.find(
-        (p) => p.postId + "-" + p.socialNetwork === comment.postKey,
+        (p) => buildPostKey(p.postId, p.socialNetwork) === comment.postKey,
       );
       if (post) {
         commentPostMap.set(comment.id, post);

--- a/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
@@ -14,6 +14,7 @@ import {
 import { useFilteredPostList } from "../Shared/useFilteredPostList";
 import React from "react";
 import { StepHeader } from "./StepHeader";
+import { Button } from "@/components/ui/button";
 
 function Step2Posts({
   reportQueryData,
@@ -24,7 +25,9 @@ function Step2Posts({
 }>) {
   const [postSortingCategory, setPostSortingCategory] =
     React.useState<PostSortingCategory>(PostSortingCategory.ANALYSIS_DATE_DESC);
-
+  const [selectedPostIds, setSelectedPostIds] = React.useState<string[]>(
+    reportQueryData?.postIdList ?? [],
+  );
   const {
     searchTerm,
     setSearchTerm,
@@ -57,6 +60,27 @@ function Step2Posts({
       />
 
       <div>
+        {selectedPostIds.length > 0 && (
+          <div className="mb-3 pe-2 w-fit gap-1 bg-muted rounded-md flex items-center justify-start font-semibold ">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => {
+                form.setFieldValue("postList", []);
+                setSelectedPostIds([]);
+              }}
+              className="text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="Déselectionner toutes les publications"
+            >
+              ✕
+            </Button>
+            <span className="text-sm">
+              {selectedPostIds.length} sélectionné
+              {selectedPostIds.length > 1 ? "s" : ""}
+            </span>
+          </div>
+        )}
+
         <SearchSortFiltersPostList
           searchTerm={searchTerm}
           setSearchTerm={setSearchTerm}
@@ -91,9 +115,9 @@ function Step2Posts({
           >
             {(field) => (
               <div className="flex flex-col gap-4">
-                <div>
+                <div className="mt-2">
                   {field.state.meta.errors.length > 0 && (
-                    <span className="text-destructive text-sm mt-2">
+                    <span className="text-destructive text-sm ">
                       {field.state.meta.errors.join(", ")}
                     </span>
                   )}
@@ -101,33 +125,36 @@ function Step2Posts({
                 {filteredPosts &&
                   filteredPosts.length > 0 &&
                   filteredPosts.map((post) => (
-                    <Card key={post.postId}>
-                      <CardContent className="flex items-center gap-5">
-                        <Checkbox
-                          id={post.postId}
-                          checked={field.state.value.includes(post.postId)}
-                          onCheckedChange={(checked) => {
-                            const currentValue = field.state.value;
-                            const nextValue = checked
-                              ? [...currentValue, post.postId]
-                              : currentValue.filter(
-                                  (val) => val !== post.postId,
-                                );
+                    <label key={post.postId}>
+                      <Card>
+                        <CardContent className="flex items-center gap-5">
+                          <Checkbox
+                            id={post.postId}
+                            checked={field.state.value.includes(post.postId)}
+                            onCheckedChange={(checked) => {
+                              const currentValue = field.state.value;
+                              const nextValue = checked
+                                ? [...currentValue, post.postId]
+                                : currentValue.filter(
+                                    (val) => val !== post.postId,
+                                  );
 
-                            field.handleChange(nextValue);
-                          }}
-                        />
-                        <div className="w-full">
-                          <PostSummary post={post} />
-                          <Card className="bg-muted mt-2 flex flex-row px-5 py-3 items-center justify-between">
-                            <div className="font-semibold">
-                              Analyse du{" "}
-                              {formatAnalysisDate(post.latestAnalysisDate)}
-                            </div>
-                          </Card>
-                        </div>
-                      </CardContent>
-                    </Card>
+                              field.handleChange(nextValue);
+                              setSelectedPostIds(nextValue);
+                            }}
+                          />
+                          <div className="w-full">
+                            <PostSummary post={post} />
+                            <Card className="bg-muted mt-2 flex flex-row px-5 py-3 items-center justify-between">
+                              <div className="font-semibold">
+                                Analyse du{" "}
+                                {formatAnalysisDate(post.latestAnalysisDate)}
+                              </div>
+                            </Card>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    </label>
                   ))}
               </div>
             )}

--- a/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
@@ -89,7 +89,10 @@ function Step2Posts({
           postSortingCategory={postSortingCategory}
           setPostSortingCategory={setPostSortingCategory}
           selectAll={() => {
-            form.setFieldValue("postList", filteredPosts.map((post) => post.postId));
+            form.setFieldValue(
+              "postList",
+              filteredPosts.map((post) => post.postId),
+            );
             setSelectedPostIds(filteredPosts.map((post) => post.postId));
           }}
         />

--- a/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
@@ -88,6 +88,10 @@ function Step2Posts({
           setPostFilters={setPostFilters}
           postSortingCategory={postSortingCategory}
           setPostSortingCategory={setPostSortingCategory}
+          selectAll={() => {
+            form.setFieldValue("postList", filteredPosts.map((post) => post.postId));
+            setSelectedPostIds(filteredPosts.map((post) => post.postId));
+          }}
         />
 
         {isLoading && <Spinner className="size-8" />}

--- a/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Step2Posts.tsx
@@ -50,85 +50,90 @@ function Step2Posts({
   });
 
   return (
-    <div className="flex flex-col gap-4 h-9/12 ">
+    <div className="flex flex-col gap-4 h-9/12 items-center">
       <StepHeader
         title="Sélectionne les publications"
         subTitle="Choisis une ou plusieurs publications à inclure dans le rapport."
       />
-      <SearchSortFiltersPostList
-        searchTerm={searchTerm}
-        setSearchTerm={setSearchTerm}
-        postFilters={postFilters}
-        setPostFilters={setPostFilters}
-        postSortingCategory={postSortingCategory}
-        setPostSortingCategory={setPostSortingCategory}
-      />
 
-      {isLoading && <Spinner className="size-8" />}
-      {!isLoading && (!filteredPosts || filteredPosts.length === 0) && (
-        <p className="text-center">Aucune publication</p>
-      )}
+      <div>
+        <SearchSortFiltersPostList
+          searchTerm={searchTerm}
+          setSearchTerm={setSearchTerm}
+          postFilters={postFilters}
+          setPostFilters={setPostFilters}
+          postSortingCategory={postSortingCategory}
+          setPostSortingCategory={setPostSortingCategory}
+        />
 
-      <form
-        id={getFormId(stepper.state.current.data.id)}
-        onSubmit={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          void form.handleSubmit();
-        }}
-        className="space-y-6 p-4 flex justify-center"
-      >
-        <form.Field
-          name="postList"
-          validators={{
-            onChange: ({ value }) =>
-              value.length < 1
-                ? "Sélectionner au moins une publication"
-                : undefined,
+        {isLoading && <Spinner className="size-8" />}
+        {!isLoading && (!filteredPosts || filteredPosts.length === 0) && (
+          <p className="text-center">Aucune publication</p>
+        )}
+
+        <form
+          id={getFormId(stepper.state.current.data.id)}
+          onSubmit={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            void form.handleSubmit();
           }}
+          className="space-y-6 flex justify-center"
         >
-          {(field) => (
-            <div className="flex flex-col gap-4">
-              <div>
-                {field.state.meta.errors.length > 0 && (
-                  <span className="text-destructive text-sm mt-2">
-                    {field.state.meta.errors.join(", ")}
-                  </span>
-                )}
-              </div>
-              {filteredPosts &&
-                filteredPosts.length > 0 &&
-                filteredPosts.map((post) => (
-                  <Card key={post.postId}>
-                    <CardContent className="flex items-center gap-5">
-                      <Checkbox
-                        id={post.postId}
-                        checked={field.state.value.includes(post.postId)}
-                        onCheckedChange={(checked) => {
-                          const currentValue = field.state.value;
-                          const nextValue = checked
-                            ? [...currentValue, post.postId]
-                            : currentValue.filter((val) => val !== post.postId);
+          <form.Field
+            name="postList"
+            validators={{
+              onChange: ({ value }) =>
+                value.length < 1
+                  ? "Sélectionner au moins une publication"
+                  : undefined,
+            }}
+          >
+            {(field) => (
+              <div className="flex flex-col gap-4">
+                <div>
+                  {field.state.meta.errors.length > 0 && (
+                    <span className="text-destructive text-sm mt-2">
+                      {field.state.meta.errors.join(", ")}
+                    </span>
+                  )}
+                </div>
+                {filteredPosts &&
+                  filteredPosts.length > 0 &&
+                  filteredPosts.map((post) => (
+                    <Card key={post.postId}>
+                      <CardContent className="flex items-center gap-5">
+                        <Checkbox
+                          id={post.postId}
+                          checked={field.state.value.includes(post.postId)}
+                          onCheckedChange={(checked) => {
+                            const currentValue = field.state.value;
+                            const nextValue = checked
+                              ? [...currentValue, post.postId]
+                              : currentValue.filter(
+                                  (val) => val !== post.postId,
+                                );
 
-                          field.handleChange(nextValue);
-                        }}
-                      />
-                      <div className="w-full">
-                        <PostSummary post={post} />
-                        <Card className="bg-muted mt-2 flex flex-row px-5 py-3 items-center justify-between">
-                          <div className="font-semibold">
-                            Analyse du{" "}
-                            {formatAnalysisDate(post.latestAnalysisDate)}
-                          </div>
-                        </Card>
-                      </div>
-                    </CardContent>
-                  </Card>
-                ))}
-            </div>
-          )}
-        </form.Field>
-      </form>
+                            field.handleChange(nextValue);
+                          }}
+                        />
+                        <div className="w-full">
+                          <PostSummary post={post} />
+                          <Card className="bg-muted mt-2 flex flex-row px-5 py-3 items-center justify-between">
+                            <div className="font-semibold">
+                              Analyse du{" "}
+                              {formatAnalysisDate(post.latestAnalysisDate)}
+                            </div>
+                          </Card>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ))}
+              </div>
+            )}
+          </form.Field>
+        </form>
+      </div>
     </div>
   );
 }

--- a/browser-extension/src/entrypoints/posts/Report/Step3Comments.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Step3Comments.tsx
@@ -2,7 +2,7 @@ import { getPostsByPostIdList } from "@/shared/storage/post-storage";
 import { ReportQueryData, useStepper } from "./BuildReport";
 import { useQuery } from "@tanstack/react-query";
 import CommentsTable, { PostCommentWithId } from "../Posts/CommentsTable";
-import { isCommentHateful } from "@/shared/utils/post-util";
+import { isCommentHateful, buildPostKey } from "@/shared/utils/post-util";
 import { Spinner } from "@/components/ui/spinner";
 import React from "react";
 import { getFormId } from "./StepperComponents";
@@ -34,7 +34,8 @@ function Step3Comments({
           (comment) =>
             ({
               ...comment,
-              postKey: `${p.postId}-${p.socialNetwork}`,
+              postKey: buildPostKey(p.postId, p.socialNetwork),
+              socialNetwork: p.socialNetwork,
             }) as PostCommentWithId,
         );
       })

--- a/browser-extension/src/entrypoints/posts/Report/Step3Comments.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/Step3Comments.tsx
@@ -53,8 +53,6 @@ function Step3Comments({
     void stepper.navigation.next();
   };
 
-  console.log("render Step3Comments : ", { allComments, reportQueryData });
-
   return (
     <>
       <StepHeader
@@ -76,6 +74,7 @@ function Step3Comments({
             onSubmit={handleSubmit}
             formId={getFormId(stepper.state.current.data.id)}
             showScreenshotColumn={true}
+            showCreateReportButton={false}
           />
         )}
       </div>

--- a/browser-extension/src/entrypoints/posts/Report/StepperComponents.tsx
+++ b/browser-extension/src/entrypoints/posts/Report/StepperComponents.tsx
@@ -1,4 +1,4 @@
-import { StepStatus, useStepItemContext } from "@stepperize/react/primitives";
+import { useStepItemContext } from "@stepperize/react/primitives";
 
 import { Button } from "@/components/ui/button";
 import { Check, MoveLeft, MoveRight } from "lucide-react";
@@ -17,6 +17,8 @@ const StepperTriggerWrapper = () => {
           roundness="round"
           variant={isInactive ? "secondary" : "default"}
           size="icon"
+          data-status={item.status}
+          className="data-[status=success]:opacity-50"
           {...domProps}
         >
           {isCompleted ? (
@@ -31,10 +33,16 @@ const StepperTriggerWrapper = () => {
 };
 
 const StepperTitleWrapper = ({ title }: { title: string }) => {
+  const item = useStepItemContext();
+
   return (
     <Stepper.Title
       render={(domProps) => (
-        <h4 className="text-sm font-medium" {...domProps}>
+        <h4
+          data-status={item.status}
+          className="text-sm font-medium data-[status=success]:opacity-50"
+          {...domProps}
+        >
           {title}
         </h4>
       )}
@@ -42,28 +50,9 @@ const StepperTitleWrapper = ({ title }: { title: string }) => {
   );
 };
 
-const StepperDescriptionWrapper = ({
-  description,
-}: {
-  description?: string;
-}) => {
-  if (!description) return null;
-  return (
-    <Stepper.Description
-      render={(domProps) => (
-        <p className="text-xs text-muted-foreground" {...domProps}>
-          {description}
-        </p>
-      )}
-    />
-  );
-};
-
 const StepperSeparatorWithLabelOrientation = ({
-  status,
   isLast,
 }: {
-  status: StepStatus;
   isLast: boolean;
 }) => {
   if (isLast) return null;
@@ -71,8 +60,7 @@ const StepperSeparatorWithLabelOrientation = ({
   return (
     <Stepper.Separator
       orientation="horizontal"
-      data-status={status}
-      className="absolute left-[calc(50%+30px)] right-[calc(-50%+20px)] top-5 block shrink-0 bg-muted data-[status=success]:bg-primary data-disabled:opacity-50 transition-all duration-300 ease-in-out h-0.5"
+      className="absolute left-[calc(80%+10px)] right-[calc(-20%+10px)] top-5 block  bg-muted h-0.5"
     />
   );
 };
@@ -83,13 +71,6 @@ export const StepperBanner = () => {
   return (
     <Stepper.List className="flex list-none gap-2 flex-row items-center justify-between">
       {stepper.state.all.map((stepData, index) => {
-        const currentIndex = stepper.state.current.index;
-        let status = "inactive";
-        if (index < currentIndex) {
-          status = "success";
-        } else if (index === currentIndex) {
-          status = "active";
-        }
         const isLast = index === stepper.state.all.length - 1;
         const data = stepData as {
           id: string;
@@ -102,15 +83,11 @@ export const StepperBanner = () => {
             step={stepData.id}
             className="group peer relative flex w-full flex-col items-center justify-center gap-2"
           >
-            <StepperTriggerWrapper />
-            <StepperSeparatorWithLabelOrientation
-              status={status as StepStatus}
-              isLast={isLast}
-            />
-            <div className="flex flex-col items-center text-center gap-1">
+            <div className="flex items-center gap-2">
+              <StepperTriggerWrapper />
               <StepperTitleWrapper title={data.title} />
-              <StepperDescriptionWrapper description={data.description} />
             </div>
+            <StepperSeparatorWithLabelOrientation isLast={isLast} />
           </Stepper.Item>
         );
       })}

--- a/browser-extension/src/entrypoints/posts/Shared/SearchSortFiltersPostList.tsx
+++ b/browser-extension/src/entrypoints/posts/Shared/SearchSortFiltersPostList.tsx
@@ -101,6 +101,7 @@ function SearchSortFiltersPostList({
   setPostFilters,
   postSortingCategory: selectedSortingCategory,
   setPostSortingCategory,
+  selectAll,
 }: Readonly<{
   searchTerm: string;
   setSearchTerm: (value: string) => void;
@@ -108,6 +109,7 @@ function SearchSortFiltersPostList({
   setPostFilters: (value: PostFilters) => void;
   postSortingCategory: PostSortingCategory;
   setPostSortingCategory: (value: PostSortingCategory) => void;
+  selectAll: () => void;
 }>) {
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [sortingOpen, setSortingOpen] = useState(false);
@@ -146,6 +148,10 @@ function SearchSortFiltersPostList({
         value={searchTerm}
         onChange={(event) => setSearchTerm(event.target.value)}
       />
+
+      <Button variant="outline" onClick={() => selectAll()}>
+        Tout sélectionner
+      </Button>
 
       <Popover open={filtersOpen} onOpenChange={handleFiltersOpenChange}>
         <PopoverTrigger>

--- a/browser-extension/src/shared/utils/post-util.ts
+++ b/browser-extension/src/shared/utils/post-util.ts
@@ -112,6 +112,13 @@ export function formatAnalysisDate(isoDateTime: string): string {
   return `${date} à ${time}`;
 }
 
+export function buildPostKey(
+  postId: string,
+  socialNetwork: SocialNetworkName,
+): string {
+  return `${postId}|${socialNetwork}`;
+}
+
 export function getSocialNetworkName(socialNetwork: SocialNetworkName): string {
   switch (socialNetwork) {
     case SocialNetwork.YouTube:

--- a/browser-extension/src/styles/global.css
+++ b/browser-extension/src/styles/global.css
@@ -91,6 +91,9 @@ main {
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
   --text-info: oklch(0.2626 0.1194 261.77);
+
+  /* A changer une fois le design system stabilisé */
+  --indigo-brand-100: oklch(0.9081 0.0367 283.95);
 }
 
 .dark {
@@ -181,6 +184,9 @@ main {
   --color-sidebar-ring: var(--sidebar-ring);
   --color-primary-background: var(--primary-background);
   --color-text-info: var(--text-info);
+
+  /* A changer une fois le design system stabilisé */
+  --color-indigo-brand-100: var(--indigo-brand-100);
 }
 
 @layer base {


### PR DESCRIPTION
fix: Correction de l'affichage de la barre des filtres de la liste des publications 
feat: ajout de la bulle "x élément(s) séléctionnés" lors de la sélection des publications et des commentaires
feat: ajout du bouton "Sélectionner tout" pour la sélection des publications et des commentaires
feat: ajouter la création du rapport à partir de la sélection faite dans la page Liste des publications (saut à l'étape 3)
feat: ajouter la création du rapport à partir de la sélection faite dans la page Détail d'une publication (saut à l'étape 4)
chore: maj du tableau des commentaires en lien avec les maquettes 
  - couleur de fond à la sélection d'une ligne
  - changement de l'icone oeil fermé 
  - changement fond entête tableau
 chore: mettre à jour l'affichage des étapes conformément aux maquettes

J'avais déjà commencé à travailler sur les redirections vers la création du rapport. 
Je propose donc d'abandonner la #343 