### PR TITLE
[Frontend] Handle content-script registration as a loading state

### DIFF
--- a/browser-extension/src/entrypoints/actions/openPostAndStartScraping.tsx
+++ b/browser-extension/src/entrypoints/actions/openPostAndStartScraping.tsx
@@ -1,5 +1,8 @@
 import { openSidePanel } from "@/entrypoints/actions/openSidePanel";
-import { ScrapingContentScriptClient } from "@/shared/scraping-content-script/ScrapingContentScriptClient";
+import {
+  CONTENT_SCRIPT_LOADING,
+  ScrapingContentScriptClient,
+} from "@/shared/scraping-content-script/ScrapingContentScriptClient";
 import { StartScrapingResult } from "@/shared/scraping-content-script/StartScrapingResult";
 import { sleep } from "@/shared/utils/sleep";
 
@@ -16,6 +19,10 @@ export async function openPostAndStartScraping(
   const start = Date.now();
   for (;;) {
     const pageInfo = await client.getTabSocialNetworkPageInfo();
+    if (pageInfo === CONTENT_SCRIPT_LOADING) {
+      await sleep(200);
+      continue;
+    }
     if (pageInfo.isScrapablePost) {
       const scrapingPromise = client.startScraping();
       await openSidePanel(newTab.id);

--- a/browser-extension/src/entrypoints/instagram.content/index.ts
+++ b/browser-extension/src/entrypoints/instagram.content/index.ts
@@ -1,8 +1,9 @@
 import { ScrapingContentScript } from "@/shared/scraping-content-script/ScrapingContentScript";
+import { INSTAGRAM_SCRAPING_CONTENT_SCRIPT_MATCHES } from "@/shared/scraping-content-script/content-script-matches";
 import { InstagramScraper } from "./InstagramScraper";
 
 export default defineContentScript({
-  matches: ["https://www.instagram.com/*"],
+  matches: INSTAGRAM_SCRAPING_CONTENT_SCRIPT_MATCHES,
   main() {
     const scraper = new InstagramScraper();
 

--- a/browser-extension/src/entrypoints/popup/Popup.tsx
+++ b/browser-extension/src/entrypoints/popup/Popup.tsx
@@ -54,7 +54,8 @@ function PopupContent() {
 
   if (
     isPending ||
-    tabInfo.type === ScrapingAndClassificationTabInfoType.NO_TAB
+    tabInfo.type === ScrapingAndClassificationTabInfoType.NO_TAB ||
+    tabInfo.type === ScrapingAndClassificationTabInfoType.CONTENT_SCRIPT_LOADING
   ) {
     return <Spinner className="size-16 m-auto" />;
   }

--- a/browser-extension/src/entrypoints/scraping-sidepanel/SidePanel.tsx
+++ b/browser-extension/src/entrypoints/scraping-sidepanel/SidePanel.tsx
@@ -55,7 +55,8 @@ export function SidePanel() {
   }
   if (
     isPending ||
-    tabInfo.type === ScrapingAndClassificationTabInfoType.NO_TAB
+    tabInfo.type === ScrapingAndClassificationTabInfoType.NO_TAB ||
+    tabInfo.type === ScrapingAndClassificationTabInfoType.CONTENT_SCRIPT_LOADING
   ) {
     return (
       <SidePanelLayout>

--- a/browser-extension/src/entrypoints/scraping-sidepanel/useScrapingAndClassificationTabInfo.tsx
+++ b/browser-extension/src/entrypoints/scraping-sidepanel/useScrapingAndClassificationTabInfo.tsx
@@ -1,6 +1,9 @@
 import { Post } from "@/shared/model/post/Post";
 import { PostSnapshot } from "@/shared/model/PostSnapshot";
-import { ScrapingContentScriptClient } from "@/shared/scraping-content-script/ScrapingContentScriptClient";
+import {
+  CONTENT_SCRIPT_LOADING,
+  ScrapingContentScriptClient,
+} from "@/shared/scraping-content-script/ScrapingContentScriptClient";
 import {
   ScrapingCanceled,
   ScrapingCanceling,
@@ -27,6 +30,7 @@ import {
  */
 export enum ScrapingAndClassificationTabInfoType {
   NO_TAB = "no-tab",
+  CONTENT_SCRIPT_LOADING = "content-script-loading",
   NOT_SCRAPABLE = "not-scrapable",
   SCRAPING_NOT_STARTED = "scraping-not-started",
   SCRAPING_NOT_STARTED_WITH_EXISTING_SNAPSHOT = "scraping-not-started-with-existing-snapshot",
@@ -81,6 +85,7 @@ export function scrapingAndClassificationTabInfoQueryKey(
 
 export type ScrapingAndClassificationTabInfo =
   | NoTabInfo
+  | ContentScriptLoadingInfo
   | TabInfoNotScrapableTab
   | TabInfoScrapingNotStarted
   | TabInfoScrapingNotStartedWithExistingSnapshot
@@ -93,6 +98,11 @@ export type ScrapingAndClassificationTabInfo =
 
 export type NoTabInfo = {
   type: ScrapingAndClassificationTabInfoType.NO_TAB;
+};
+
+export type ContentScriptLoadingInfo = {
+  type: ScrapingAndClassificationTabInfoType.CONTENT_SCRIPT_LOADING;
+  tabId: number;
 };
 
 export type TabInfoNotScrapableTab = {
@@ -167,6 +177,12 @@ export async function queryScrapingAndClassificationTabInfo(
   }
   const client = new ScrapingContentScriptClient(tabId);
   const pageInfo = await client.getTabSocialNetworkPageInfo();
+  if (pageInfo === CONTENT_SCRIPT_LOADING) {
+    return {
+      type: ScrapingAndClassificationTabInfoType.CONTENT_SCRIPT_LOADING,
+      tabId,
+    };
+  }
 
   if (!pageInfo.isScrapablePost) {
     return { type: ScrapingAndClassificationTabInfoType.NOT_SCRAPABLE, tabId };

--- a/browser-extension/src/entrypoints/youtube.content/index.ts
+++ b/browser-extension/src/entrypoints/youtube.content/index.ts
@@ -1,8 +1,9 @@
 import { ScrapingContentScript } from "@/shared/scraping-content-script/ScrapingContentScript";
+import { YOUTUBE_SCRAPING_CONTENT_SCRIPT_MATCHES } from "@/shared/scraping-content-script/content-script-matches";
 import { YoutubeScraper } from "./YoutubeScraper";
 
 export default defineContentScript({
-  matches: ["https://www.youtube.com/*"],
+  matches: YOUTUBE_SCRAPING_CONTENT_SCRIPT_MATCHES,
   main() {
     const scraper = new YoutubeScraper();
 

--- a/browser-extension/src/shared/scraping-content-script/ScrapingContentScriptClient.ts
+++ b/browser-extension/src/shared/scraping-content-script/ScrapingContentScriptClient.ts
@@ -11,6 +11,7 @@ import {
 import { StartScrapingResult } from "./StartScrapingResult";
 import { SocialNetworkPageInfo } from "./SocialNetworkPageInfo";
 import { ScrapingStatus } from "./ScrapingStatus";
+import { matchesScrapingContentScriptUrl } from "./content-script-matches";
 
 /**
  * Client to communicate with content script in a specific tabId.
@@ -22,17 +23,22 @@ export class ScrapingContentScriptClient {
   /**
    * Get information on a social network page
    */
-  async getTabSocialNetworkPageInfo(): Promise<SocialNetworkPageInfo> {
-    const response = await this.safeSendMessage<
-      ScsPageInfoMessage,
-      SocialNetworkPageInfo
-    >(SCS_GET_PAGE_INFO_MESSAGE);
-    if (response === NO_CONTENT_SCRIPT) {
-      // undefined response means  Content script for url
+  async getTabSocialNetworkPageInfo(): Promise<
+    SocialNetworkPageInfo | typeof CONTENT_SCRIPT_LOADING
+  > {
+    if (!(await this.isContentScriptRegisteredForTabUrl())) {
       console.debug("No content script in tab " + this.tabId);
       return {
         isScrapablePost: false,
       };
+    }
+    const response = await this.safeSendMessage<
+      ScsPageInfoMessage,
+      SocialNetworkPageInfo
+    >(SCS_GET_PAGE_INFO_MESSAGE);
+    if (response === CONTENT_SCRIPT_NOT_RESPONDING) {
+      console.debug("Content script loading");
+      return CONTENT_SCRIPT_LOADING;
     }
     return response;
   }
@@ -42,11 +48,10 @@ export class ScrapingContentScriptClient {
       ScsScrapTabMessage,
       StartScrapingResult
     >(SCS_SCRAP_TAB_MESSAGE);
-    if (response === NO_CONTENT_SCRIPT) {
-      // No Scraping Content script registered for this url
+    if (response === CONTENT_SCRIPT_NOT_RESPONDING) {
       return {
         type: "failed",
-        errorMessage: "No Scraping Content script registered for this url",
+        errorMessage: "Content script not responding",
       };
     }
     return response;
@@ -60,11 +65,9 @@ export class ScrapingContentScriptClient {
       ScsGetScrapingStatusMessage,
       ScrapingStatus
     >(SCS_GET_SCRAPING_STATUS_MESSAGE);
-    if (response === NO_CONTENT_SCRIPT) {
+    if (response === CONTENT_SCRIPT_NOT_RESPONDING) {
       // Tab does not have a scraping content script
-      return Promise.reject(
-        new Error("No Scraping Content script registered for this url"),
-      );
+      return Promise.reject(new Error("Content script not responding"));
     }
     return response;
   }
@@ -76,14 +79,14 @@ export class ScrapingContentScriptClient {
     const response = await this.safeSendMessage<ScsCancelScrapTabMessage, null>(
       SCS_CANCEL_SCRAP_TAB_MESSAGE,
     );
-    if (response === NO_CONTENT_SCRIPT) {
-      throw new Error("No Scraping Content script registered for this url");
+    if (response === CONTENT_SCRIPT_NOT_RESPONDING) {
+      throw new Error("Content script not responding");
     }
   }
 
   private async safeSendMessage<M, R>(
     message: M,
-  ): Promise<R | typeof NO_CONTENT_SCRIPT> {
+  ): Promise<R | typeof CONTENT_SCRIPT_NOT_RESPONDING> {
     try {
       return await browser.tabs.sendMessage<M, R>(this.tabId, message);
     } catch (e) {
@@ -92,12 +95,18 @@ export class ScrapingContentScriptClient {
           "Error: Could not establish connection. Receiving end does not exist.",
         )
       ) {
-        console.debug("No content  script listening in tab " + this.tabId);
-        return NO_CONTENT_SCRIPT;
+        console.debug("Content script not responding in tab " + this.tabId);
+        return CONTENT_SCRIPT_NOT_RESPONDING;
       }
       throw e;
     }
   }
+
+  private async isContentScriptRegisteredForTabUrl(): Promise<boolean> {
+    const tab = await browser.tabs.get(this.tabId);
+    return matchesScrapingContentScriptUrl(tab.url);
+  }
 }
 
-const NO_CONTENT_SCRIPT = "NO_CONTENT_SCRIPT" as const;
+const CONTENT_SCRIPT_NOT_RESPONDING = "NO_CONTENT_SCRIPT" as const;
+export const CONTENT_SCRIPT_LOADING = "CONTENT_SCRIPT_LOADING" as const;

--- a/browser-extension/src/shared/scraping-content-script/__tests__/content-script-matches.test.ts
+++ b/browser-extension/src/shared/scraping-content-script/__tests__/content-script-matches.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { matchesScrapingContentScriptUrl } from "../content-script-matches";
+
+describe("matchesScrapingContentScriptUrl", () => {
+  it("matches urls where a scraping content script is registered", () => {
+    expect(
+      matchesScrapingContentScriptUrl("https://www.youtube.com/watch?v=abc"),
+    ).toBe(true);
+    expect(
+      matchesScrapingContentScriptUrl("https://www.instagram.com/p/abc"),
+    ).toBe(true);
+  });
+
+  it("does not match urls without a scraping content script", () => {
+    expect(matchesScrapingContentScriptUrl("https://example.com")).toBe(false);
+    expect(matchesScrapingContentScriptUrl("chrome://extensions")).toBe(false);
+    expect(matchesScrapingContentScriptUrl(undefined)).toBe(false);
+  });
+});

--- a/browser-extension/src/shared/scraping-content-script/content-script-matches.ts
+++ b/browser-extension/src/shared/scraping-content-script/content-script-matches.ts
@@ -1,0 +1,72 @@
+export const INSTAGRAM_SCRAPING_CONTENT_SCRIPT_MATCHES = [
+  "https://www.instagram.com/*",
+];
+
+export const YOUTUBE_SCRAPING_CONTENT_SCRIPT_MATCHES = [
+  "https://www.youtube.com/*",
+];
+
+export const SCRAPING_CONTENT_SCRIPT_MATCHES = [
+  ...INSTAGRAM_SCRAPING_CONTENT_SCRIPT_MATCHES,
+  ...YOUTUBE_SCRAPING_CONTENT_SCRIPT_MATCHES,
+];
+
+export function matchesScrapingContentScriptUrl(url: string | undefined) {
+  if (!url) {
+    return false;
+  }
+
+  return SCRAPING_CONTENT_SCRIPT_MATCHES.some((matchPattern) =>
+    matchesWebExtensionMatchPattern(url, matchPattern),
+  );
+}
+
+function matchesWebExtensionMatchPattern(url: string, matchPattern: string) {
+  const parsedPattern = /^(\*|http|https|file|ftp):\/\/([^/]+)(\/.*)$/.exec(
+    matchPattern,
+  );
+  if (!parsedPattern) {
+    throw new Error(`Invalid content script match pattern: ${matchPattern}`);
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return false;
+  }
+
+  const [, schemePattern, hostPattern, pathPattern] = parsedPattern;
+  return (
+    matchesScheme(parsedUrl.protocol.slice(0, -1), schemePattern) &&
+    matchesHost(parsedUrl.hostname, hostPattern) &&
+    matchesPath(parsedUrl.pathname, pathPattern)
+  );
+}
+
+function matchesScheme(scheme: string, schemePattern: string) {
+  if (schemePattern === "*") {
+    return scheme === "http" || scheme === "https";
+  }
+  return scheme === schemePattern;
+}
+
+function matchesHost(host: string, hostPattern: string) {
+  if (hostPattern === "*") {
+    return true;
+  }
+  if (hostPattern.startsWith("*.")) {
+    const suffix = hostPattern.slice(2);
+    return host === suffix || host.endsWith(`.${suffix}`);
+  }
+  return host === hostPattern;
+}
+
+function matchesPath(path: string, pathPattern: string) {
+  return wildcardPatternToRegex(pathPattern).test(path);
+}
+
+function wildcardPatternToRegex(pattern: string) {
+  const escapedPattern = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escapedPattern.replaceAll("*", ".*")}$`);
+}


### PR DESCRIPTION
- Treat pending content-script registration as a loading state
- Keep popup and side panel on spinners until the script responds
- Share scraping match patterns and add URL matching tests

Fixes #347 