### PR TITLE
[E2E] refactor and support youtube shorts in CI

### DIFF
--- a/.github/workflows/web-extension.yaml
+++ b/.github/workflows/web-extension.yaml
@@ -199,6 +199,9 @@ jobs:
         run: pnpm exec playwright install chromium
       - name: Build extension
         run: pnpm build
+        env:
+          # Enable degraded scrapping to still scrap even if some data is missing due to bot suspicieon
+          VITE_YT_ALLOW_DEGRADED_SCRAPPING: true
 
       - name: Install xvfb
         run: sudo apt-get install xvfb

--- a/browser-extension/CONTRIBUTING.md
+++ b/browser-extension/CONTRIBUTING.md
@@ -22,9 +22,13 @@ Vérifier le formatage et le lint de code:
 
 - Lancer les tests unitaires (vitest): `pnpm test`
 - Lancer les tests end 2 end (playwright):
-  - **Necessite que `pnpm dev` soit lancé à coté**
+  - **Nécessite que `pnpm dev` soit lancé à coté**
   - `pnpm test:e2e` execute les tests et affiche le rapport.
   - `pnpm test:e2e:ui` lance les tests end-to-end avec Playwright UI.
+  - Optionnel: Lancer les tests en étant authentifié sur les plateformes de réseau
+    - Démarrer chromium et s'authentifier à Instagram & Youtube
+    - Définir la variable d'environnement `PATH_TO_BROWSER_CONTEXT` pour pointer vers le profile chrome existant
+    - Lancer la commande de test e2e de sont choix: e.g. `PATH_TO_BROWSER_CONTEXT=~/.config/chromium/ pnpm test:e2e:ui`
 
 # Configurer l'extension pour pointer vers le backend de classification locale
 

--- a/browser-extension/e2e/E2E_TESTED_LOCALES.ts
+++ b/browser-extension/e2e/E2E_TESTED_LOCALES.ts
@@ -1,0 +1,1 @@
+export const E2E_TESTED_LOCALES = ["en-US", "fr-FR"] as const;

--- a/browser-extension/e2e/extension-integration/evaluate/evaluateInBackgroundWorker.ts
+++ b/browser-extension/e2e/extension-integration/evaluate/evaluateInBackgroundWorker.ts
@@ -7,6 +7,9 @@ export async function evaluateInBackgroundWorker<T>(
   // eslint-disable-next-line
   arg?: any,
 ): Promise<T> {
+  if (context.isClosed()) {
+    throw new Error("Context closed");
+  }
   const backgroundWorker = context.serviceWorkers()[0];
   if (!backgroundWorker) {
     throw new NoBackgroundWorker();

--- a/browser-extension/e2e/extension-integration/storage/e2eDeleteAllPostSnapshots.ts
+++ b/browser-extension/e2e/extension-integration/storage/e2eDeleteAllPostSnapshots.ts
@@ -1,0 +1,11 @@
+import { BrowserContext } from "@playwright/test";
+import { evaluateInBackgroundWorker } from "../evaluate/evaluateInBackgroundWorker";
+
+export async function e2eDeleteAllPostSnapshots(
+  context: BrowserContext,
+): Promise<void> {
+  const clearPostStorage = async () => {
+    await browser.storage.local.remove("posts");
+  };
+  await evaluateInBackgroundWorker(context, clearPostStorage);
+}

--- a/browser-extension/e2e/fixtures.ts
+++ b/browser-extension/e2e/fixtures.ts
@@ -19,18 +19,23 @@ export const test = base.extend<ExtensionFixtures>({
       __dirname,
       process.env.PATH_TO_EXTENSION || CHROME_BUILD_PATH,
     );
-    const context = await chromium.launchPersistentContext("", {
-      headless: false, // Extensions require headed mode
-      args: [
-        `--disable-extensions-except=${pathToExtension}`,
-        `--load-extension=${pathToExtension}`,
-        "--mute-audio",
-      ],
-      viewport: {
-        width: 1920,
-        height: 1080,
+    const pathToBrowserContext = process.env.PATH_TO_BROWSER_CONTEXT || "";
+    console.log("using pathToBrowserContext", pathToBrowserContext);
+    const context = await chromium.launchPersistentContext(
+      pathToBrowserContext,
+      {
+        headless: false, // Extensions require headed mode
+        args: [
+          `--disable-extensions-except=${pathToExtension}`,
+          `--load-extension=${pathToExtension}`,
+          "--mute-audio",
+        ],
+        viewport: {
+          width: 1920,
+          height: 1080,
+        },
       },
-    });
+    );
     await use(context);
     await context.close();
   },

--- a/browser-extension/e2e/fixtures.ts
+++ b/browser-extension/e2e/fixtures.ts
@@ -20,7 +20,9 @@ export const test = base.extend<ExtensionFixtures>({
       process.env.PATH_TO_EXTENSION || CHROME_BUILD_PATH,
     );
     const pathToBrowserContext = process.env.PATH_TO_BROWSER_CONTEXT || "";
-    console.log("using pathToBrowserContext", pathToBrowserContext);
+    if (pathToBrowserContext) {
+      console.log("[E2E] using pathToBrowserContext:", pathToBrowserContext);
+    }
     const context = await chromium.launchPersistentContext(
       pathToBrowserContext,
       {

--- a/browser-extension/e2e/instagram-reel-scraping.spec.ts
+++ b/browser-extension/e2e/instagram-reel-scraping.spec.ts
@@ -11,8 +11,8 @@ import { expectSomeCommentsToHaveEmojis } from "./utils/expectSomeCommentsToHave
 
 E2E_TESTED_LOCALES.forEach((locale) => {
   test.describe(`Instagram Reel Scrapping (locale:${locale})`, () => {
-    test.use({ locale: locale });
     test.describe.configure({ mode: "serial" });
+    test.use({ locale: locale });
 
     const reelId = "DX9g-fpCIbF";
     const account = "feministsinthecity";
@@ -30,7 +30,6 @@ E2E_TESTED_LOCALES.forEach((locale) => {
     });
 
     test(`Check post metadata`, () => {
-      test.skip(scrappingResult === undefined);
       const { postSnapshot } = scrappingResult;
 
       checkPostSnapshotGenericExpectations(postSnapshot);
@@ -47,7 +46,6 @@ E2E_TESTED_LOCALES.forEach((locale) => {
     });
 
     test(`Check top level comments`, () => {
-      test.skip(scrappingResult === undefined);
       // Check comments
       const topLevelComments = scrappingResult.postSnapshot.comments;
 

--- a/browser-extension/e2e/instagram-reel-scraping.spec.ts
+++ b/browser-extension/e2e/instagram-reel-scraping.spec.ts
@@ -1,74 +1,82 @@
 import { test, expect } from "./fixtures";
-import { flattenComments } from "./utils/flattenComments";
 import { instagramReelUrl } from "./scraping/instagram/instagramReelUrl";
 import { e2eScrapPost, E2EScrapPostResult } from "./scraping/e2eScrapPost";
 import { openAndPrepareInstagramPage } from "./scraping/instagram/openAndPrepareInstagramPage";
-import { isInstagramPageAuthenticated } from "./scraping/instagram/isInstagramPageAuthenticated";
+import { SocialNetwork } from "@/shared/model/SocialNetworkName";
+import { checkPostSnapshotGenericExpectations } from "./utils/checkPostSnapshotGenericExpectations";
+import { expectCommentsToMatchInvariants } from "./utils/expectCommentsToMatchInvariants";
+import { E2E_TESTED_LOCALES } from "./E2E_TESTED_LOCALES";
+import { expectSomeCommentsToHaveLikes } from "./utils/expectSomeCommentsToHaveLikes";
+import { expectSomeCommentsToHaveEmojis } from "./utils/expectSomeCommentsToHaveEmojis";
 
-["en-US", "fr-FR"].forEach((locale) => {
-  test.describe("Scraping reel with Locale:" + locale, () => {
+E2E_TESTED_LOCALES.forEach((locale) => {
+  test.describe(`Instagram Reel Scrapping (locale:${locale})`, () => {
     test.use({ locale: locale });
+    test.describe.configure({ mode: "serial" });
 
-    test(`Test scraping reel smoke test locale:${locale}`, async ({
-      extensionId,
-      context,
-    }, testInfo) => {
-      const reelId = "DX9g-fpCIbF";
-      const postUrl = instagramReelUrl("feministsinthecity", reelId);
+    const reelId = "DX9g-fpCIbF";
+    const account = "feministsinthecity";
+    const postUrl = instagramReelUrl(account, reelId);
 
-      const { postSnapshot: post, authenticated }: E2EScrapPostResult =
-        await e2eScrapPost({
-          postUrl,
-          openAndPreparePage: openAndPrepareInstagramPage,
-          detectAuthenticated: isInstagramPageAuthenticated,
-          context,
-          extensionId,
-          testInfo,
-        });
+    let scrappingResult: E2EScrapPostResult;
+    test(`Run scrapping`, async ({ extensionId, context }, testInfo) => {
+      scrappingResult = await e2eScrapPost({
+        postUrl,
+        openAndPreparePage: openAndPrepareInstagramPage,
+        context,
+        extensionId,
+        testInfo,
+      });
+    });
+
+    test(`Check post metadata`, () => {
+      test.skip(scrappingResult === undefined);
+      const { postSnapshot } = scrappingResult;
+
+      checkPostSnapshotGenericExpectations(postSnapshot);
 
       // Test post values
-      expect(post.postId).toEqual(reelId);
-      expect(post.url).toEqual(postUrl);
-      expect(post.publishedAt).toEqual({
+      expect(postSnapshot.postId).toEqual(reelId);
+      expect(postSnapshot.url).toEqual(postUrl);
+      expect(postSnapshot.publishedAt).toEqual({
         type: "absolute",
         date: "2026-05-05T00:00:00.000Z",
       });
-      expect(new Date(post.scrapedAt).getTime()).toBeLessThan(Date.now());
+      expect(postSnapshot.socialNetwork).toEqual(SocialNetwork.Instagram);
+      expect(postSnapshot.author.name).toEqual(account);
+    });
 
+    test(`Check top level comments`, () => {
+      test.skip(scrappingResult === undefined);
       // Check comments
-      const topLevelComments = post.comments;
-
-      const allComments = flattenComments(topLevelComments);
+      const topLevelComments = scrappingResult.postSnapshot.comments;
 
       // Ensure have top level comments
       expect(topLevelComments.length).toBeGreaterThan(0);
 
-      // Test all comment have commentId
-      expect(allComments.every((comment) => comment.commentId !== null)).toBe(
-        true,
+      expectCommentsToMatchInvariants(topLevelComments);
+
+      expectSomeCommentsToHaveEmojis(topLevelComments);
+
+      expectSomeCommentsToHaveLikes(topLevelComments);
+    });
+
+    test(`Check first level replies data`, () => {
+      test.skip(
+        scrappingResult === undefined || !scrappingResult.authenticated,
+        "Not Authenticated: skipping replies checks as instagram replies are not available when not authenticated.",
       );
 
-      // Test some comments have emojis
-      expect(
-        allComments.some((c) =>
-          /\p{Extended_Pictographic}/u.test(c.textContent),
-        ),
-      ).toBeTruthy();
+      // Replies are only present in instagram if authenticated
+      // TODO: document how to use a chrome profile with an authenticated session for local test
+      const firstLevelReplies = scrappingResult.postSnapshot.comments.flatMap(
+        (c) => c.replies,
+      );
+      expect(firstLevelReplies.length).toBeGreaterThan(0);
+      expectCommentsToMatchInvariants(firstLevelReplies);
+      expectSomeCommentsToHaveEmojis(firstLevelReplies);
 
-      // Test likes parsing: at least one comment with >0 likes
-      expect(allComments.some((comment) => comment.nbLikes > 0)).toBe(true);
-
-      // Test comments have text
-      expect(
-        allComments.some((comment) => comment.textContent.length > 0),
-      ).toBe(true);
-
-      if (authenticated) {
-        // Replies are only present in instagram if authenticated
-        // TODO: document how to use a chrome profile with an authenticated session for local test
-        const firstLevelReplies = topLevelComments.flatMap((c) => c.replies);
-        expect(firstLevelReplies.length).toBeGreaterThan(0);
-      }
+      expectSomeCommentsToHaveLikes(firstLevelReplies);
     });
   });
 });

--- a/browser-extension/e2e/scraping/e2eScrapPost.ts
+++ b/browser-extension/e2e/scraping/e2eScrapPost.ts
@@ -3,12 +3,14 @@ import { ScrapingSucceeded } from "@/shared/scraping-content-script/ScrapingStat
 import { BrowserContext, Page, TestInfo } from "@playwright/test";
 import { e2eWaitForScrapingSuccess } from "./e2eWaitForScrapingSuccess";
 import { triggerPageScrappingAndWaitForRunning } from "./e2eTriggerPageScrapping";
+import { e2eDeleteAllPostSnapshots } from "../extension-integration/storage/e2eDeleteAllPostSnapshots";
 
 export type E2EScrapPostResult = {
   postUrl: string;
   postPage: Page;
   postTabId: number;
-  authenticated?: boolean;
+  authenticated: boolean;
+  platformSuspectingBot: boolean;
   scrapingStatus: ScrapingSucceeded;
   postSnapshot: PostSnapshot;
 };
@@ -16,7 +18,6 @@ export type E2EScrapPostResult = {
 export async function e2eScrapPost({
   postUrl,
   openAndPreparePage,
-  detectAuthenticated,
   context,
   extensionId,
   testInfo,
@@ -26,18 +27,12 @@ export async function e2eScrapPost({
 }: {
   postUrl: string;
   /**
-   * Prepare page after open (ensure loading, close cookie dialog)
-   * @param page
-   * @returns
+   * Open and prepare page for scrapping (ensure loading, close cookie dialog, detect logged in)
    */
   openAndPreparePage: (
     postUrl: string,
     context: BrowserContext,
-  ) => Promise<Page>;
-  detectAuthenticated?: (
-    page: Page,
-    context: BrowserContext,
-  ) => Promise<boolean>;
+  ) => Promise<OpenAndPrepareResult>;
 
   extensionId: string;
   testInfo: TestInfo;
@@ -56,16 +51,16 @@ export async function e2eScrapPost({
   testInfo.setTimeout(pageSetupTimeout);
 
   console.info("[E2E] Opening and preparing page (url " + postUrl + ") ...");
-  const postPage: Page = await openAndPreparePage(postUrl, context);
-  console.info("[E2E] Post page ready.");
-
-  const authenticated = detectAuthenticated
-    ? await detectAuthenticated(postPage, context)
-    : undefined;
-  console.info("[E2E] Post page authenticated:", authenticated);
+  const { postPage, authenticated, platformSuspectingBot } =
+    await openAndPreparePage(postUrl, context);
+  console.info(
+    "[E2E] Post page prepared:",
+    JSON.stringify({ authenticated, platformSuspectingBot }),
+  );
 
   const pageScrappingStart = Date.now();
   testInfo.setTimeout(pageScrappingStart - start + scrapingTimeout);
+  await e2eDeleteAllPostSnapshots(context);
   const triggerResult = await triggerPageScrappingAndWaitForRunning({
     postPage,
     context,
@@ -88,7 +83,14 @@ export async function e2eScrapPost({
     postPage,
     postTabId: triggerResult.postTabId,
     authenticated,
+    platformSuspectingBot,
     scrapingStatus: scrapingSuccess.status,
     postSnapshot: scrapingSuccess.postSnapshot,
   };
 }
+
+export type OpenAndPrepareResult = {
+  postPage: Page;
+  authenticated: boolean;
+  platformSuspectingBot: boolean;
+};

--- a/browser-extension/e2e/scraping/e2eTriggerPageScrapping.ts
+++ b/browser-extension/e2e/scraping/e2eTriggerPageScrapping.ts
@@ -29,7 +29,7 @@ export async function triggerPageScrappingAndWaitForRunning({
 
   await popupPage.clickStartScrapingButton();
   await postPage.bringToFront();
-  await e2eWaitForScrapingRunning(
+  await e2eWaitForScrapingStarted(
     waitForScrappingRunningTimeout,
     context,
     postTabId,
@@ -40,7 +40,7 @@ export async function triggerPageScrappingAndWaitForRunning({
   };
 }
 
-async function e2eWaitForScrapingRunning(
+async function e2eWaitForScrapingStarted(
   timeout: number,
   context: BrowserContext,
   scrapingTabId: number,
@@ -52,7 +52,7 @@ async function e2eWaitForScrapingRunning(
         context,
         scrapingTabId,
       );
-      return status !== undefined && status.type === "running";
+      return status !== undefined && status.type !== "not-started";
     },
   });
 }

--- a/browser-extension/e2e/scraping/e2eTriggerPageScrapping.ts
+++ b/browser-extension/e2e/scraping/e2eTriggerPageScrapping.ts
@@ -3,6 +3,10 @@ import { PopupPageObject } from "../po/PopupPageObject";
 import { e2eQueryTabIdWithUrl } from "../extension-integration/e2eQueryTabIdWithUrl";
 import { waitForConditionOrThrow } from "../utils/waitForCondition";
 import { e2eGetScrapingStatusOrUndefinedIfNoCS } from "../extension-integration/cs/e2eGetScrapingStatus";
+import {
+  isScrapingInProgress,
+  isScrapingCompleted,
+} from "@/shared/scraping-content-script/ScrapingStatus";
 
 export type TriggerScrapingResult = {
   popupPage: PopupPageObject;
@@ -52,7 +56,10 @@ async function e2eWaitForScrapingStarted(
         context,
         scrapingTabId,
       );
-      return status !== undefined && status.type !== "not-started";
+      return (
+        status !== undefined &&
+        (isScrapingInProgress(status) || isScrapingCompleted(status))
+      );
     },
   });
 }

--- a/browser-extension/e2e/scraping/instagram/openAndPrepareInstagramPage.ts
+++ b/browser-extension/e2e/scraping/instagram/openAndPrepareInstagramPage.ts
@@ -1,10 +1,12 @@
 import { waitForCondition } from "@@/e2e/utils/waitForCondition";
 import { BrowserContext, Page } from "@playwright/test";
+import { isInstagramPageAuthenticated } from "./isInstagramPageAuthenticated";
+import { OpenAndPrepareResult } from "../e2eScrapPost";
 
 export async function openAndPrepareInstagramPage(
   postUrl: string,
   context: BrowserContext,
-): Promise<Page> {
+): Promise<OpenAndPrepareResult> {
   const postPage: Page = await context.newPage();
   await postPage.goto(postUrl, { waitUntil: "domcontentloaded" });
   console.info("[E2E] domcontentloaded.");
@@ -36,7 +38,13 @@ export async function openAndPrepareInstagramPage(
   } else {
     console.info("[E2E] Login dialog not found after timeout");
   }
-  return postPage;
+
+  const authenticated = await isInstagramPageAuthenticated(postPage);
+  return {
+    postPage,
+    authenticated,
+    platformSuspectingBot: false,
+  };
 }
 
 async function closeCookieDialogIfPresent(page: Page): Promise<boolean> {

--- a/browser-extension/e2e/scraping/youtube/isYoutubeAuthenticated.ts
+++ b/browser-extension/e2e/scraping/youtube/isYoutubeAuthenticated.ts
@@ -1,9 +1,14 @@
 import { Page } from "@playwright/test";
 
 export async function isYoutubeAuthenticated(page: Page): Promise<boolean> {
-  return (
-    (await page
-      .locator("a[aria-label='Sign in'],a[aria-label='Se connecter']")
-      .count()) === 0
-  );
+  // login button is present when NOT authenticated
+  const loginButtonLocator = page
+    .locator("a[aria-label='Sign in'],a[aria-label='Se connecter']")
+    .first();
+  // avatar button is present  when authenticated
+  const avatarButtonLocator = page.locator("button#avatar-btn");
+  const combinedLocator = loginButtonLocator.or(avatarButtonLocator);
+  const isAvatarButton =
+    (await combinedLocator.evaluate((e) => e.id)) === "avatar-btn";
+  return isAvatarButton;
 }

--- a/browser-extension/e2e/scraping/youtube/isYoutubeAuthenticated.ts
+++ b/browser-extension/e2e/scraping/youtube/isYoutubeAuthenticated.ts
@@ -1,0 +1,9 @@
+import { Page } from "@playwright/test";
+
+export async function isYoutubeAuthenticated(page: Page): Promise<boolean> {
+  return (
+    (await page
+      .locator("a[aria-label='Sign in'],a[aria-label='Se connecter']")
+      .count()) === 0
+  );
+}

--- a/browser-extension/e2e/scraping/youtube/isYoutubeSuspectingBot.ts
+++ b/browser-extension/e2e/scraping/youtube/isYoutubeSuspectingBot.ts
@@ -1,0 +1,10 @@
+import { Page } from "@playwright/test";
+
+export async function isYoutubeSuspectingBot(page: Page): Promise<boolean> {
+  return (
+    (await page.getByText("Sign in to confirm you're not a bot").count()) > 0 ||
+    (await page
+      .getByText("Connectez-vous pour confirmer que vous n'êtes pas un robot")
+      .count()) > 0
+  );
+}

--- a/browser-extension/e2e/scraping/youtube/isYoutubeSuspectingBot.ts
+++ b/browser-extension/e2e/scraping/youtube/isYoutubeSuspectingBot.ts
@@ -2,9 +2,7 @@ import { Page } from "@playwright/test";
 
 export async function isYoutubeSuspectingBot(page: Page): Promise<boolean> {
   return (
-    (await page.getByText("Sign in to confirm you're not a bot").count()) > 0 ||
-    (await page
-      .getByText("Connectez-vous pour confirmer que vous n'êtes pas un robot")
-      .count()) > 0
+    (await page.getByText("not a bot").count()) > 0 ||
+    (await page.getByText("pas un robot").count()) > 0
   );
 }

--- a/browser-extension/e2e/scraping/youtube/openAndPrepareYoutubeShortsPage.ts
+++ b/browser-extension/e2e/scraping/youtube/openAndPrepareYoutubeShortsPage.ts
@@ -30,6 +30,6 @@ export async function openAndPrepareYoutubeShortsPage(
   return {
     postPage,
     authenticated,
-    platformSuspectingBot: platformSuspectingBot,
+    platformSuspectingBot,
   };
 }

--- a/browser-extension/e2e/scraping/youtube/openAndPrepareYoutubeShortsPage.ts
+++ b/browser-extension/e2e/scraping/youtube/openAndPrepareYoutubeShortsPage.ts
@@ -1,10 +1,13 @@
 import { BrowserContext, Page } from "@playwright/test";
 import { closeYoutubeCookieDialogIfPresent } from "./closeYoutubeCookieDialogIfPresent";
+import { OpenAndPrepareResult } from "../e2eScrapPost";
+import { isYoutubeSuspectingBot } from "./isYoutubeSuspectingBot";
+import { isYoutubeAuthenticated } from "./isYoutubeAuthenticated";
 
 export async function openAndPrepareYoutubeShortsPage(
   postUrl: string,
   context: BrowserContext,
-): Promise<Page> {
+): Promise<OpenAndPrepareResult> {
   const postPage: Page = await context.newPage();
   await postPage.goto(postUrl, { waitUntil: "domcontentloaded" });
   console.info("[E2E] domcontentloaded.");
@@ -21,5 +24,12 @@ export async function openAndPrepareYoutubeShortsPage(
     timeout: 15000,
   });
 
-  return postPage;
+  const authenticated = await isYoutubeAuthenticated(postPage);
+  const platformSuspectingBot = await isYoutubeSuspectingBot(postPage);
+
+  return {
+    postPage,
+    authenticated,
+    platformSuspectingBot: platformSuspectingBot,
+  };
 }

--- a/browser-extension/e2e/scraping/youtube/openAndPrepareYoutubeVideoPage.ts
+++ b/browser-extension/e2e/scraping/youtube/openAndPrepareYoutubeVideoPage.ts
@@ -1,10 +1,13 @@
 import { BrowserContext, Page } from "@playwright/test";
 import { closeYoutubeCookieDialogIfPresent as waitAndCloseYoutubeCookieDialogIfPresent } from "./closeYoutubeCookieDialogIfPresent";
+import { isYoutubeAuthenticated } from "./isYoutubeAuthenticated";
+import { OpenAndPrepareResult } from "../e2eScrapPost";
+import { isYoutubeSuspectingBot } from "./isYoutubeSuspectingBot";
 
 export async function openAndPrepareYoutubeVideoPage(
   postUrl: string,
   context: BrowserContext,
-): Promise<Page> {
+): Promise<OpenAndPrepareResult> {
   const postPage: Page = await context.newPage();
   await postPage.goto(postUrl, { waitUntil: "domcontentloaded" });
   console.info("[E2E] domcontentloaded.");
@@ -20,5 +23,12 @@ export async function openAndPrepareYoutubeVideoPage(
   });
 
   await waitAndCloseYoutubeCookieDialogIfPresent(postPage);
-  return postPage;
+  const authenticated = await isYoutubeAuthenticated(postPage);
+  const platformSuspectingBot = await isYoutubeSuspectingBot(postPage);
+
+  return {
+    postPage,
+    authenticated,
+    platformSuspectingBot,
+  };
 }

--- a/browser-extension/e2e/utils/checkPostSnapshotGenericExpectations.ts
+++ b/browser-extension/e2e/utils/checkPostSnapshotGenericExpectations.ts
@@ -1,0 +1,21 @@
+import { PostSnapshot } from "@/shared/model/PostSnapshot";
+import { expect } from "@playwright/test";
+
+export function checkPostSnapshotGenericExpectations(
+  postSnapshot: PostSnapshot,
+) {
+  expect(postSnapshot.id).toBeDefined();
+  expect(postSnapshot.postId).toBeDefined();
+  expect(postSnapshot.url).toBeDefined();
+  expect(postSnapshot.coverImageUrl).toBeDefined();
+  expect(postSnapshot.author).toBeDefined();
+  expect(postSnapshot.author.name).toBeDefined();
+  expect(postSnapshot.author.accountHref).toBeDefined();
+  expect(postSnapshot.publishedAt.type).toBe("absolute");
+  if (postSnapshot.publishedAt.type === "absolute") {
+    expect(new Date(postSnapshot.publishedAt.date).getTime()).toBeLessThan(
+      Date.now(),
+    );
+  }
+  expect(new Date(postSnapshot.scrapedAt).getTime()).toBeLessThan(Date.now());
+}

--- a/browser-extension/e2e/utils/expectCommentsToMatchInvariants.ts
+++ b/browser-extension/e2e/utils/expectCommentsToMatchInvariants.ts
@@ -1,0 +1,30 @@
+import { CommentSnapshot } from "@/shared/model/PostSnapshot";
+import { expect } from "@playwright/test";
+
+export function expectCommentsToMatchInvariants(comments: CommentSnapshot[]) {
+  expect(
+    comments.every((comment) => comment.commentId !== null),
+    "All comments should have a commentId",
+  ).toBe(true);
+
+  // Test comments have text
+  expect(
+    comments.every((comment) => comment.textContent.length > 0),
+    "Comments should have text",
+  ).toBe(true);
+
+  expect(
+    comments.every((comment) => comment.screenshotData.length > 0),
+    "Comments should have screenshot data",
+  ).toBe(true);
+
+  expect(
+    comments.every((comment) => comment.author.name.length > 0),
+    "Comments should have author name",
+  ).toBe(true);
+
+  expect(
+    comments.every((comment) => comment.author.accountHref.length > 0),
+    "Comments should have author href",
+  ).toBe(true);
+}

--- a/browser-extension/e2e/utils/expectSomeCommentsToHaveEmojis.ts
+++ b/browser-extension/e2e/utils/expectSomeCommentsToHaveEmojis.ts
@@ -1,0 +1,9 @@
+import { CommentSnapshot } from "@/shared/model/PostSnapshot";
+import { expect } from "@playwright/test";
+
+export function expectSomeCommentsToHaveEmojis(comments: CommentSnapshot[]) {
+  expect(
+    comments.some((c) => /\p{Extended_Pictographic}/u.test(c.textContent)),
+    "Some comments should have an emojis",
+  ).toBeTruthy();
+}

--- a/browser-extension/e2e/utils/expectSomeCommentsToHaveLikes.ts
+++ b/browser-extension/e2e/utils/expectSomeCommentsToHaveLikes.ts
@@ -1,0 +1,9 @@
+import { CommentSnapshot } from "@/shared/model/PostSnapshot";
+import { expect } from "@playwright/test";
+
+export function expectSomeCommentsToHaveLikes(comments: CommentSnapshot[]) {
+  expect(
+    comments.some((comment) => comment.nbLikes > 0),
+    "Some comments should have likes",
+  ).toBe(true);
+}

--- a/browser-extension/e2e/youtube-shorts-scraping.spec.ts
+++ b/browser-extension/e2e/youtube-shorts-scraping.spec.ts
@@ -1,63 +1,80 @@
 import { test, expect } from "./fixtures";
 import { youtubeShortUrl } from "./scraping/youtube/youtubeShortUrl";
-import { flattenComments } from "./utils/flattenComments";
 import { e2eScrapPost, E2EScrapPostResult } from "./scraping/e2eScrapPost";
 import { openAndPrepareYoutubeShortsPage } from "./scraping/youtube/openAndPrepareYoutubeShortsPage";
+import { E2E_TESTED_LOCALES } from "./E2E_TESTED_LOCALES";
+import { checkPostSnapshotGenericExpectations } from "./utils/checkPostSnapshotGenericExpectations";
+import { expectCommentsToMatchInvariants } from "./utils/expectCommentsToMatchInvariants";
+import { expectSomeCommentsToHaveEmojis } from "./utils/expectSomeCommentsToHaveEmojis";
+import { expectSomeCommentsToHaveLikes } from "./utils/expectSomeCommentsToHaveLikes";
 
-test.describe("Youtube Shorts Scraping", () => {
-  test.use({ locale: "fr-FR" });
+E2E_TESTED_LOCALES.forEach((locale) => {
+  test.describe(`Youtube Shorts Scrapping (locale:${locale})`, () => {
+    test.use({ locale });
+    test.describe.configure({ mode: "serial" });
 
-  test("Test scraping short public without authentication", async ({
-    extensionId,
-    context,
-  }, testInfo) => {
-    test.skip(
-      !!process.env.CI,
-      "Skipped in CI because blocked by youtube in CI",
-    );
+    const postId = "WPpURgqzXZ4";
+    const postUrl = youtubeShortUrl(postId);
 
-    const youtubeShortId = "WPpURgqzXZ4";
-    const postUrl = youtubeShortUrl(youtubeShortId);
-
-    const { postSnapshot: post }: E2EScrapPostResult = await e2eScrapPost({
-      postUrl,
-      openAndPreparePage: openAndPrepareYoutubeShortsPage,
-      context,
-      extensionId,
-      testInfo,
+    let scrappingResult: E2EScrapPostResult;
+    test(`Run scrapping`, async ({ extensionId, context }, testInfo) => {
+      scrappingResult = await e2eScrapPost({
+        postUrl,
+        openAndPreparePage: openAndPrepareYoutubeShortsPage,
+        context,
+        extensionId,
+        testInfo,
+      });
     });
 
-    expect(post.postId).toEqual(youtubeShortId);
-    expect(post.url).toEqual(postUrl);
-    expect(post.publishedAt).toEqual({
-      type: "absolute",
-      date: "2025-02-19T17:00:41.000Z",
+    test(`Check post metadata`, () => {
+      test.skip(scrappingResult === undefined);
+      const { postSnapshot } = scrappingResult;
+
+      checkPostSnapshotGenericExpectations(postSnapshot);
+      expect(postSnapshot.postId).toEqual(postId);
+      expect(postSnapshot.url).toEqual(postUrl);
+      expect(postSnapshot.publishedAt).toEqual({
+        type: "absolute",
+        date: "2025-02-19T17:00:41.000Z",
+      });
+
+      if (scrappingResult.platformSuspectingBot) {
+        // When youtube suspect we are a bot it prevents shorts title scrapping
+        expect(postSnapshot.title).toBeUndefined();
+      } else {
+        expect(postSnapshot.title).toContain(
+          "Celles et ceux qui ne voulaient pas être ce qu’elles/ils étaient",
+        );
+      }
     });
-    expect(new Date(post.scrapedAt).getTime()).toBeLessThan(Date.now());
 
-    // Check comments
-    const topLevelComments = post.comments;
-    const firstLevelReplies = topLevelComments.flatMap((c) => c.replies);
+    test(`Check comments`, () => {
+      test.skip(scrappingResult === undefined);
+      const { postSnapshot } = scrappingResult;
 
-    const allComments = flattenComments(topLevelComments);
+      // Check comments
+      const topLevelComments = postSnapshot.comments;
 
-    // Ensure have top level comments
-    expect(topLevelComments.length).toBeGreaterThan(0);
-    // Ensure have replies
-    expect(firstLevelReplies.length).toBeGreaterThan(0);
+      // Ensure have top level comments
+      expect(topLevelComments.length).toBeGreaterThan(0);
+      expectCommentsToMatchInvariants(topLevelComments);
 
-    // Test all comment have commentId
-    expect(allComments.every((comment) => comment.commentId !== null)).toBe(
-      true,
-    );
+      expectSomeCommentsToHaveEmojis(topLevelComments);
 
-    // Test all comments have text
-    expect(allComments.every((comment) => comment.textContent.length > 0)).toBe(
-      true,
-    );
-    // Test all comments have screenshotData
-    expect(
-      allComments.every((comment) => comment.screenshotData.length > 0),
-    ).toBe(true);
+      expectSomeCommentsToHaveLikes(topLevelComments);
+    });
+
+    test(`Check first level replies`, () => {
+      test.skip(scrappingResult === undefined);
+      const { postSnapshot } = scrappingResult;
+
+      // Check comments
+      const firstLevelReplies = postSnapshot.comments.flatMap((c) => c.replies);
+
+      // Ensure have replies
+      expect(firstLevelReplies.length).toBeGreaterThan(0);
+      expectCommentsToMatchInvariants(firstLevelReplies);
+    });
   });
 });

--- a/browser-extension/e2e/youtube-shorts-scraping.spec.ts
+++ b/browser-extension/e2e/youtube-shorts-scraping.spec.ts
@@ -7,11 +7,12 @@ import { checkPostSnapshotGenericExpectations } from "./utils/checkPostSnapshotG
 import { expectCommentsToMatchInvariants } from "./utils/expectCommentsToMatchInvariants";
 import { expectSomeCommentsToHaveEmojis } from "./utils/expectSomeCommentsToHaveEmojis";
 import { expectSomeCommentsToHaveLikes } from "./utils/expectSomeCommentsToHaveLikes";
+import { PUBLISHED_AT_PLACEHOLDER_FOR_DEGRADED_SCRAPPING } from "@/entrypoints/youtube.content/PUBLISHED_AT_PLACEHOLDER_FOR_DEGRADED_SCRAPPING";
 
 E2E_TESTED_LOCALES.forEach((locale) => {
   test.describe(`Youtube Shorts Scrapping (locale:${locale})`, () => {
-    test.use({ locale });
     test.describe.configure({ mode: "serial" });
+    test.use({ locale });
 
     const postId = "WPpURgqzXZ4";
     const postUrl = youtubeShortUrl(postId);
@@ -28,29 +29,30 @@ E2E_TESTED_LOCALES.forEach((locale) => {
     });
 
     test(`Check post metadata`, () => {
-      test.skip(scrappingResult === undefined);
       const { postSnapshot } = scrappingResult;
 
       checkPostSnapshotGenericExpectations(postSnapshot);
       expect(postSnapshot.postId).toEqual(postId);
       expect(postSnapshot.url).toEqual(postUrl);
-      expect(postSnapshot.publishedAt).toEqual({
-        type: "absolute",
-        date: "2025-02-19T17:00:41.000Z",
-      });
 
       if (scrappingResult.platformSuspectingBot) {
-        // When youtube suspect we are a bot it prevents shorts title scrapping
+        // When youtube suspect we are a bot it prevents og meta scrapping
         expect(postSnapshot.title).toBeUndefined();
+        expect(postSnapshot.publishedAt).toEqual(
+          PUBLISHED_AT_PLACEHOLDER_FOR_DEGRADED_SCRAPPING,
+        );
       } else {
         expect(postSnapshot.title).toContain(
           "Celles et ceux qui ne voulaient pas être ce qu’elles/ils étaient",
         );
+        expect(postSnapshot.publishedAt).toEqual({
+          type: "absolute",
+          date: "2025-02-19T17:00:41.000Z",
+        });
       }
     });
 
     test(`Check comments`, () => {
-      test.skip(scrappingResult === undefined);
       const { postSnapshot } = scrappingResult;
 
       // Check comments
@@ -66,7 +68,6 @@ E2E_TESTED_LOCALES.forEach((locale) => {
     });
 
     test(`Check first level replies`, () => {
-      test.skip(scrappingResult === undefined);
       const { postSnapshot } = scrappingResult;
 
       // Check comments

--- a/browser-extension/e2e/youtube-video-scraping.spec.ts
+++ b/browser-extension/e2e/youtube-video-scraping.spec.ts
@@ -3,89 +3,99 @@ import { flattenComments } from "./utils/flattenComments";
 import { youtubeVideoUrl } from "./scraping/youtube/youtubeVideoUrl";
 import { e2eScrapPost, E2EScrapPostResult } from "./scraping/e2eScrapPost";
 import { openAndPrepareYoutubeVideoPage } from "./scraping/youtube/openAndPrepareYoutubeVideoPage";
+import { E2E_TESTED_LOCALES } from "./E2E_TESTED_LOCALES";
+import { checkPostSnapshotGenericExpectations } from "./utils/checkPostSnapshotGenericExpectations";
+import { expectCommentsToMatchInvariants } from "./utils/expectCommentsToMatchInvariants";
+import { expectSomeCommentsToHaveLikes } from "./utils/expectSomeCommentsToHaveLikes";
+import { expectSomeCommentsToHaveEmojis } from "./utils/expectSomeCommentsToHaveEmojis";
 
-["en-US", "fr-FR"].forEach((locale) => {
-  test.describe("Youtube Video Scraping with Locale:" + locale, () => {
+E2E_TESTED_LOCALES.forEach((locale) => {
+  test.describe(`Youtube Video Scrapping (locale:${locale})`, () => {
     test.use({ locale: locale });
+    const postId = "bYnBcdxT7os";
 
-    test(`Test scraping video locale:${locale}`, async ({
-      extensionId,
-      context,
-    }, testInfo) => {
-      // Note: the scraping part (until the waitForPostStored)
-      // should ideally be moved to a beforeAll
-      // However this requires to figure out how to
-      //  install extension before the beforeAll...
-      const youtubeVideoId = "bYnBcdxT7os";
-      const postUrl = youtubeVideoUrl(youtubeVideoId);
+    const postUrl = youtubeVideoUrl(postId);
 
-      const { postSnapshot: post, postPage }: E2EScrapPostResult =
-        await e2eScrapPost({
-          postUrl,
-          openAndPreparePage: openAndPrepareYoutubeVideoPage,
-          context,
-          extensionId,
-          testInfo,
-        });
-
-      // Test post values
-      expect(post.postId).toEqual(youtubeVideoId);
-      expect(post.url).toEqual(postUrl);
-      expect(post.publishedAt).toEqual({
-        type: "absolute",
-        date: "2025-07-22T00:00:00.000Z",
+    let scrappingResult: E2EScrapPostResult;
+    let expectedCommentCount: number;
+    test(`Run scrapping`, async ({ extensionId, context }, testInfo) => {
+      scrappingResult = await e2eScrapPost({
+        postUrl,
+        openAndPreparePage: openAndPrepareYoutubeVideoPage,
+        context,
+        extensionId,
+        testInfo,
       });
-      expect(new Date(post.scrapedAt).getTime()).toBeLessThan(Date.now());
 
-      // Check comments
-      const topLevelComments = post.comments;
-      const allComments = flattenComments(topLevelComments);
-      expect(topLevelComments.length).toBeGreaterThan(0);
-      expect(allComments.length).toBeGreaterThan(0);
-
-      // Test commentId captured
-      const commentForId = topLevelComments.find(
-        (c) => typeof c.commentId === "string" && c.commentId.length > 10,
-      );
-      expect(commentForId).toBeDefined();
-      expect(commentForId?.commentId).toMatch(/^[a-zA-Z0-9_-]+$/);
-
-      // Test emojis are captured on at least one comment
-      const commentWithEmojis = topLevelComments.find((c) =>
-        /\p{Extended_Pictographic}/u.test(c.textContent),
-      );
-      expect(commentWithEmojis).toBeDefined();
-
-      // Test long comment is captured
-      const longComment = topLevelComments.find(
-        (c) => c.textContent.length > 80,
-      );
-      expect(longComment).toBeDefined();
-      expect(longComment?.textContent.length).toBeGreaterThan(80);
-
-      // Test likes parsing is present on top-level comments
-      expect(topLevelComments.every((comment) => comment.nbLikes >= 0)).toBe(
-        true,
-      );
-
-      // Replies can change over time on public videos. If any reply exists,
-      // assert its text has been captured.
-      const firstReply = topLevelComments.find((c) => c.replies.length > 0)
-        ?.replies[0];
-      if (firstReply) {
-        expect(firstReply.textContent.length).toBeGreaterThan(0);
-      }
-
-      // Test that total scraped comment count matches youtube displayed count
-      const commentCountElement = await postPage.$(
+      const commentCountElement = await scrappingResult.postPage.$(
         "#comments #count span:nth-of-type(1)",
       );
       const text = (await commentCountElement?.innerText()) || "0";
-      const commentCount = Number.parseInt(text);
-      expect(allComments.length).toBeLessThanOrEqual(commentCount);
-      expect(allComments.length).toBeGreaterThanOrEqual(
-        Math.floor(commentCount * 0.7),
+      expectedCommentCount = Number.parseInt(text);
+    });
+
+    test(`Check post metadata`, () => {
+      test.skip(scrappingResult === undefined);
+      const { postSnapshot } = scrappingResult;
+
+      checkPostSnapshotGenericExpectations(postSnapshot);
+      expect(postSnapshot.postId).toEqual(postId);
+      expect(postSnapshot.url).toEqual(postUrl);
+      expect(postSnapshot.publishedAt).toEqual({
+        type: "absolute",
+        date: "2025-07-22T00:00:00.000Z",
+      });
+      expect(postSnapshot.title).toContain("Cher Corps");
+    });
+
+    test(`Check top level comments`, () => {
+      test.skip(scrappingResult === undefined);
+      const { postSnapshot } = scrappingResult;
+
+      // Check comments
+      const topLevelComments = postSnapshot.comments;
+
+      // Ensure have top level comments
+      expect(topLevelComments.length).toBeGreaterThan(0);
+      expectCommentsToMatchInvariants(topLevelComments);
+
+      expectSomeCommentsToHaveEmojis(topLevelComments);
+      expectSomeCommentsToHaveLikes(topLevelComments);
+
+      // Test long comment is captured
+      expect(
+        topLevelComments.find((c) => c.textContent.length > 80),
+        "Cher Corps",
+      ).toBeDefined();
+    });
+
+    test("All comments count", () => {
+      test.skip(scrappingResult === undefined);
+      const allComments = flattenComments(
+        scrappingResult.postSnapshot.comments,
       );
+
+      // Test that total scraped comment count matches youtube displayed count
+
+      expect(allComments.length).toBeLessThanOrEqual(expectedCommentCount);
+      expect(allComments.length).toBeGreaterThanOrEqual(
+        Math.floor(expectedCommentCount * 0.7),
+      );
+    });
+
+    test(`Check first level replies`, () => {
+      test.skip(scrappingResult === undefined);
+      const { postSnapshot } = scrappingResult;
+
+      // Check comments
+      const firstLevelReplies = postSnapshot.comments.flatMap((c) => c.replies);
+
+      // Ensure have replies
+      expect(firstLevelReplies.length).toBeGreaterThan(0);
+      expectCommentsToMatchInvariants(firstLevelReplies);
+
+      expectSomeCommentsToHaveEmojis(firstLevelReplies);
+      expectSomeCommentsToHaveLikes(firstLevelReplies);
     });
   });
 });

--- a/browser-extension/e2e/youtube-video-scraping.spec.ts
+++ b/browser-extension/e2e/youtube-video-scraping.spec.ts
@@ -9,6 +9,8 @@ import { expectCommentsToMatchInvariants } from "./utils/expectCommentsToMatchIn
 import { expectSomeCommentsToHaveLikes } from "./utils/expectSomeCommentsToHaveLikes";
 import { expectSomeCommentsToHaveEmojis } from "./utils/expectSomeCommentsToHaveEmojis";
 
+const EXPECTED_MINIMUM_COMMENT_RATIO = 0.7;
+
 E2E_TESTED_LOCALES.forEach((locale) => {
   test.describe(`Youtube Video Scrapping (locale:${locale})`, () => {
     test.describe.configure({ mode: "serial" });
@@ -80,7 +82,7 @@ E2E_TESTED_LOCALES.forEach((locale) => {
 
       expect(allComments.length).toBeLessThanOrEqual(expectedCommentCount);
       expect(allComments.length).toBeGreaterThanOrEqual(
-        Math.floor(expectedCommentCount * 0.7),
+        Math.floor(expectedCommentCount * EXPECTED_MINIMUM_COMMENT_RATIO),
       );
     });
 

--- a/browser-extension/e2e/youtube-video-scraping.spec.ts
+++ b/browser-extension/e2e/youtube-video-scraping.spec.ts
@@ -11,6 +11,7 @@ import { expectSomeCommentsToHaveEmojis } from "./utils/expectSomeCommentsToHave
 
 E2E_TESTED_LOCALES.forEach((locale) => {
   test.describe(`Youtube Video Scrapping (locale:${locale})`, () => {
+    test.describe.configure({ mode: "serial" });
     test.use({ locale: locale });
     const postId = "bYnBcdxT7os";
 

--- a/browser-extension/src/entrypoints/youtube.content/PUBLISHED_AT_PLACEHOLDER_FOR_DEGRADED_SCRAPPING.ts
+++ b/browser-extension/src/entrypoints/youtube.content/PUBLISHED_AT_PLACEHOLDER_FOR_DEGRADED_SCRAPPING.ts
@@ -1,0 +1,4 @@
+export const PUBLISHED_AT_PLACEHOLDER_FOR_DEGRADED_SCRAPPING = {
+  type: "absolute",
+  date: "2000-01-01T00:00:00.000Z",
+} as const;

--- a/browser-extension/src/entrypoints/youtube.content/YoutubeScraper.ts
+++ b/browser-extension/src/entrypoints/youtube.content/YoutubeScraper.ts
@@ -12,6 +12,12 @@ import { createLogger } from "@/shared/utils/createLogger";
 const logger = createLogger("[CS - YoutubeScraper]");
 
 export class YoutubeScraper implements SocialNetworkScraper {
+  /**
+   *
+   * @param allowDegradedScrapping try to still perform scrapping if youtube suspects bot at the risk of erroneous data. Usefull only for E2E test
+   */
+  constructor(private allowDegradedScrapping: boolean) {}
+
   getSocialNetworkPageInfo(): Promise<SocialNetworkPageInfo> {
     return Promise.resolve(youtubePageInfo(document.URL));
   }
@@ -20,6 +26,9 @@ export class YoutubeScraper implements SocialNetworkScraper {
     abortSignal: AbortSignal,
     progressManager: ProgressManager,
   ): Promise<ScrapPagePostResult> {
+    if (this.allowDegradedScrapping) {
+      console.warn("allowDegradedScrapping=true. This is only for testing");
+    }
     const scrapingSupport = new ScrapingSupport(abortSignal);
     const ogUrl = scrapingSupport.select(
       document,
@@ -28,10 +37,13 @@ export class YoutubeScraper implements SocialNetworkScraper {
     )?.content;
 
     if (!ogUrl) {
-      // This happens in E2E test when not logged in and youtube suspects bot.
-      logger.warn(
-        "Failed to find og:url no way to check if og:metadata is out of sync.",
-      );
+      const message =
+        "Failed to find og:url no way to check if og:metadata is out of sync.";
+      if (this.allowDegradedScrapping) {
+        logger.warn(message);
+      } else {
+        throw new Error(message);
+      }
     } else if (isOutdatedOgMeta(ogUrl, document.URL)) {
       // Scraper uses og: meta information which are only loaded on page load not on navigation
       // Detect if out of sync by comparing ogUrl postId with current url postId
@@ -41,9 +53,10 @@ export class YoutubeScraper implements SocialNetworkScraper {
       };
     }
 
-    return new YoutubePostNativeScrapper(scrapingSupport).scrapPost(
-      progressManager,
-    );
+    return new YoutubePostNativeScrapper(
+      scrapingSupport,
+      this.allowDegradedScrapping,
+    ).scrapPost(progressManager);
   }
 }
 

--- a/browser-extension/src/entrypoints/youtube.content/index.ts
+++ b/browser-extension/src/entrypoints/youtube.content/index.ts
@@ -5,7 +5,10 @@ import { YoutubeScraper } from "./YoutubeScraper";
 export default defineContentScript({
   matches: YOUTUBE_SCRAPING_CONTENT_SCRIPT_MATCHES,
   main() {
-    const scraper = new YoutubeScraper();
+    const allowDegradedScrapping = Boolean(
+      import.meta.env.VITE_YT_ALLOW_DEGRADED_SCRAPPING,
+    );
+    const scraper = new YoutubeScraper(allowDegradedScrapping);
 
     new ScrapingContentScript(scraper).initialize();
   },

--- a/browser-extension/src/entrypoints/youtube.content/youtube-post-native-scrapper.ts
+++ b/browser-extension/src/entrypoints/youtube.content/youtube-post-native-scrapper.ts
@@ -27,6 +27,8 @@ import { withRetry } from "../../shared/utils/withRetry";
 import { SocialNetwork } from "@/shared/model/SocialNetworkName";
 import { parseCommentPublishedTime } from "./parseCommentPublishedTime";
 import { extractBase64DataFromDataUrl } from "@/shared/utils/data-url";
+import { createLogger } from "@/shared/utils/createLogger";
+import { PUBLISHED_AT_PLACEHOLDER_FOR_DEGRADED_SCRAPPING } from "./PUBLISHED_AT_PLACEHOLDER_FOR_DEGRADED_SCRAPPING";
 const LOG_PREFIX = "[CS - YoutubePostNativeScrapper] ";
 const YOUTUBE_SHORTS_PATH_SEGMENT = "/shorts/";
 const YOUTUBE_SHORTS_COMMENTS_PANEL_SELECTOR =
@@ -42,21 +44,15 @@ type CommentThread =
   | { scrapingStatus: "success"; comment: CommentSnapshot }
   | { scrapingStatus: "failure"; message: string };
 
+const logger = createLogger(LOG_PREFIX);
 export class YoutubePostNativeScrapper {
-  public constructor(private scrapingSupport: ScrapingSupport) {}
-
-  private debug(...data: unknown[]) {
-    console.debug(LOG_PREFIX, ...data);
-  }
-  private info(...data: unknown[]) {
-    console.info(LOG_PREFIX, ...data);
-  }
-  private warn(...data: unknown[]) {
-    console.warn(LOG_PREFIX, ...data);
-  }
+  public constructor(
+    private scrapingSupport: ScrapingSupport,
+    private allowDegradedScrapping: boolean,
+  ) {}
 
   async scrapPost(progressManager: ProgressManager): Promise<PostSnapshot> {
-    this.info("Start Scraping... ", document.URL);
+    logger.info("Start Scraping... ", document.URL);
     const url = document.URL;
     const pageInfo = youtubePageInfo(url);
     if (!pageInfo.isScrapablePost) {
@@ -66,7 +62,7 @@ export class YoutubePostNativeScrapper {
     const isShortsPost = this.isShortsPostUrl(url);
 
     // Pause video to ensure it doesn't autoplay next video during scraping..."
-    this.debug("Pause video...");
+    logger.debug("Pause video...");
     (
       await this.scrapingSupport.waitForSelectorOrThrow(
         document,
@@ -75,26 +71,26 @@ export class YoutubePostNativeScrapper {
       )
     ).pause();
 
-    this.debug("Scraping title...");
+    logger.debug("Scraping title...");
     const title = this.scrapPostTitle(isShortsPost);
-    this.debug(`title: ${title}`);
+    logger.debug(`title: ${title}`);
 
-    this.debug("Scraping author...");
+    logger.debug("Scraping author...");
     const author = await this.scrapPostAuthor(isShortsPost);
-    this.debug(`author.name: ${author.name}`);
+    logger.debug(`author.name: ${author.name}`);
 
-    this.debug("Scraping textContent...");
+    logger.debug("Scraping textContent...");
     const textConent = this.scrapPostTextContent(isShortsPost);
-    this.debug(`textContent: ${textConent.replaceAll("\n", "")}`);
+    logger.debug(`textContent: ${textConent.replaceAll("\n", "")}`);
 
-    this.debug("Scraping publishedAt...");
+    logger.debug("Scraping publishedAt...");
     const publishedAt = await this.scrapPostPublishedAt(isShortsPost);
-    this.debug(`publishedAt: ${JSON.stringify(publishedAt)}`);
+    logger.debug(`publishedAt: ${JSON.stringify(publishedAt)}`);
 
     // Init accounts for 1%
     progressManager.setProgress(1);
 
-    this.debug("Scraping comments...");
+    logger.debug("Scraping comments...");
     const comments: CommentSnapshot[] = await this.scrapPostComments(
       isShortsPost,
       // Scraping comments accounts for 99% of progress
@@ -115,7 +111,7 @@ export class YoutubePostNativeScrapper {
     };
   }
 
-  private scrapPostTitle(isShortsPost: boolean): string {
+  private scrapPostTitle(isShortsPost: boolean): string | undefined {
     if (!isShortsPost) {
       const titleElement = this.scrapingSupport.select(
         document,
@@ -132,7 +128,13 @@ export class YoutubePostNativeScrapper {
       return shortTitle;
     }
 
-    throw new Error("Failed to scrap post title");
+    const message =
+      "Failed to find og:title. Maybe youtube is considering we are a bot. Returning undefined";
+    if (this.allowDegradedScrapping) {
+      logger.warn(message);
+    } else {
+      throw new Error(message);
+    }
   }
 
   private scrapPostTextContent(isShortsPost: boolean): string {
@@ -189,7 +191,15 @@ export class YoutubePostNativeScrapper {
       'meta[itemprop="datePublished"]',
     );
     if (!rawPublishedDate) {
-      throw new Error("Failed to scrap post published date");
+      const errorMessage = "Failed to scrap post published date";
+      if (this.allowDegradedScrapping) {
+        logger.warn(errorMessage);
+
+        // Placeholder date
+        return PUBLISHED_AT_PLACEHOLDER_FOR_DEGRADED_SCRAPPING;
+      } else {
+        throw new Error(errorMessage);
+      }
     }
 
     const parsedDate = new Date(rawPublishedDate);
@@ -276,14 +286,14 @@ export class YoutubePostNativeScrapper {
       commentsSectionHandle.scrollIntoView();
     }
 
-    this.debug("Sorting comments by newest...");
+    logger.debug("Sorting comments by newest...");
     await this.sortCommentsByNewest(commentsSectionHandle, isShortsPost);
 
     const expectedCommentCount = this.extractExpectedCommentCount(
       commentsSectionHandle,
       isShortsPost,
     );
-    this.debug("Expecting ", expectedCommentCount, " comments");
+    logger.debug("Expecting ", expectedCommentCount, " comments");
 
     await this.loadAllComments(
       commentsSectionHandle,
@@ -298,7 +308,7 @@ export class YoutubePostNativeScrapper {
 
     const scrapedCommentCount = countAllComments(comments);
     if (expectedCommentCount !== scrapedCommentCount) {
-      this.warn(
+      logger.warn(
         "Total comments count mismatch: expected",
         expectedCommentCount,
         " scraped:",
@@ -380,18 +390,18 @@ export class YoutubePostNativeScrapper {
       maxAttempts: 10,
       retryOn: (e) => e instanceof WindowResizedSinceScreenshotError,
       beforeRetry: ({ remainingAttempts }) => {
-        this.warn(
+        logger.warn(
           "Window Resized - restarting scrapLoadedComments remainingAttempts:",
           remainingAttempts,
         );
       },
       retry: async () => {
-        this.info("Capturing full page screenshot");
+        logger.info("Capturing full page screenshot");
         const fullPageScreenshot = await this.capturePageScreenshot(
           progressManager.subTaskProgressManager({ from: 0, to: 95 }),
         );
 
-        this.info("Capturing comment threads...");
+        logger.info("Capturing comment threads...");
         const threadContainers = this.scrapingSupport.selectAll(
           commentsSectionHandle,
           "#contents > ytd-comment-thread-renderer",
@@ -403,7 +413,7 @@ export class YoutubePostNativeScrapper {
           new Set<string>(),
         );
         progressManager.setProgress(100);
-        this.debug("Comments metada:", comments);
+        logger.debug("Comments metada:", comments);
         return comments;
       },
     });
@@ -414,17 +424,17 @@ export class YoutubePostNativeScrapper {
     isShortsPost: boolean,
     progressManager: ProgressManager,
   ) {
-    this.info("Loading all comments...");
+    logger.info("Loading all comments...");
 
-    this.debug("Loading top level comments...");
+    logger.debug("Loading top level comments...");
     await this.loadAllTopLevelComments(commentsContainer, isShortsPost);
     progressManager.setProgress(50);
 
-    this.debug("Expanding all replies...");
+    logger.debug("Expanding all replies...");
     await this.loadAllReplies(commentsContainer, isShortsPost);
     progressManager.setProgress(75);
 
-    this.debug("Expanding long comments...");
+    logger.debug("Expanding long comments...");
     await this.expandLongComments(commentsContainer, isShortsPost);
     progressManager.setProgress(100);
   }
@@ -486,7 +496,7 @@ export class YoutubePostNativeScrapper {
       throw new Error("Unexpected undefined commentId");
     }
     if (collectedPostIds.has(comment.commentId)) {
-      this.warn(
+      logger.warn(
         "Ignoring duplicate comment from ",
         comment.author.name,
         " with id ",
@@ -588,7 +598,7 @@ export class YoutubePostNativeScrapper {
       HTMLElement,
     );
     if (!sortMenu || !this.scrapingSupport.isVisible(sortMenu)) {
-      this.warn("Sort menu not found");
+      logger.warn("Sort menu not found");
       return;
     }
     sortMenu.scrollIntoView();
@@ -656,7 +666,7 @@ export class YoutubePostNativeScrapper {
       const visibleCommentsCount = this.scrapingSupport
         .selectAll(commentsContainer, "#comment-container", HTMLElement)
         .filter((e) => this.scrapingSupport.isVisible(e)).length;
-      this.debug(
+      logger.debug(
         "loadAllTopLevelComments - ",
         visibleCommentsCount,
         " comments loaded",
@@ -686,7 +696,7 @@ export class YoutubePostNativeScrapper {
         HTMLElement,
       )
       .filter((e) => this.scrapingSupport.isVisible(e));
-    this.debug("Expanding ", repliesButton.length, " replies button...");
+    logger.debug("Expanding ", repliesButton.length, " replies button...");
     await this.expandReplies(repliesButton, commentsContainer, isShortsPost);
 
     // expand more replies button
@@ -708,7 +718,7 @@ export class YoutubePostNativeScrapper {
           clickedMoreRepliesButtons.has(b),
         );
       if (selectedButAlreadyClickedButSelected.length > 0) {
-        this.warn(
+        logger.warn(
           "Found ",
           selectedButAlreadyClickedButSelected.length,
           " more replies button for which click didn't work!! Ignoring them to avoid infinite loop.",
@@ -721,10 +731,12 @@ export class YoutubePostNativeScrapper {
       );
 
       if (selectedAndNotYetClicked.length === 0) {
-        this.debug("Found 0 more replies button - We're done loading replies.");
+        logger.debug(
+          "Found 0 more replies button - We're done loading replies.",
+        );
         return;
       } else {
-        this.debug(
+        logger.debug(
           "Found ",
           selectedAndNotYetClicked.length,
           " more replies buttons - Expanding them",
@@ -746,7 +758,7 @@ export class YoutubePostNativeScrapper {
     commentsContainer: HTMLElement,
     isShortsPost: boolean,
   ) {
-    this.debug("Loading ", repliesButton.length, " replies...");
+    logger.debug("Loading ", repliesButton.length, " replies...");
     for (const button of repliesButton) {
       if (!isShortsPost) {
         button.scrollIntoView();
@@ -757,7 +769,7 @@ export class YoutubePostNativeScrapper {
     // Wait for replies to load
     await this.waitForRepliesToLoad(commentsContainer, isShortsPost);
 
-    this.debug("All ", repliesButton.length, "replies loaded");
+    logger.debug("All ", repliesButton.length, "replies loaded");
   }
 
   private async expandLongComments(
@@ -767,7 +779,7 @@ export class YoutubePostNativeScrapper {
     const readMoreButton = this.scrapingSupport
       .selectAll(commentsContainer, "#more", HTMLElement)
       .filter((e) => this.scrapingSupport.isVisible(e));
-    this.debug("Expanding ", readMoreButton.length, " read more buttons...");
+    logger.debug("Expanding ", readMoreButton.length, " read more buttons...");
     for (const b of readMoreButton) {
       if (!isShortsPost) {
         b.scrollIntoView();
@@ -791,7 +803,7 @@ export class YoutubePostNativeScrapper {
     );
     const publishedTimeText = publishedTimeElement.innerText;
     const publishedAt = parseCommentPublishedTime(publishedTimeText);
-    this.debug(`publishedAtInfo: ${JSON.stringify(publishedAt)}`);
+    logger.debug(`publishedAtInfo: ${JSON.stringify(publishedAt)}`);
 
     const commentHref = this.scrapingSupport.selectOrThrow(
       publishedTimeElement,
@@ -883,7 +895,7 @@ export class YoutubePostNativeScrapper {
     const right = Math.min(imageWidth, originX + rawWidth);
     const bottom = Math.min(imageHeight, originY + rawHeight);
     if (right <= left || bottom <= top) {
-      this.warn("Skipping out-of-bounds comment screenshot", {
+      logger.warn("Skipping out-of-bounds comment screenshot", {
         originX,
         originY,
         rawWidth,
@@ -905,7 +917,7 @@ export class YoutubePostNativeScrapper {
       });
       return uint8ArrayToBase64(encodePng(screenshotImage));
     } catch (e) {
-      this.warn("Failed to crop comment screenshot", {
+      logger.warn("Failed to crop comment screenshot", {
         error: String(e),
         originX,
         originY,
@@ -951,7 +963,7 @@ export class YoutubePostNativeScrapper {
       }
       return uint8ArrayToBase64(encodePng(segment.image));
     } catch (e) {
-      this.warn("Failed to capture visible comment screenshot", String(e));
+      logger.warn("Failed to capture visible comment screenshot", String(e));
       return "";
     }
   }
@@ -1308,13 +1320,13 @@ export class YoutubePostNativeScrapper {
       if (remainingGhostSectionsCount === 0) {
         return remainingGhostSectionsCount;
       }
-      this.debug(
+      logger.debug(
         ` ${remainingGhostSectionsCount}/${initialGhostSectionsCount} still present after ${Date.now() - start}ms.`,
       );
       if (Date.now() > maxDate) {
         // Assuming we are facing broken replies loading.
         // See https://github.com/dataforgoodfr/14_BalanceTesHaters/issues/304
-        this.warn(
+        logger.warn(
           `Adaptive timeout reached after ${Date.now() - start}ms. Assuming broken replies loading.`,
         );
         return remainingGhostSectionsCount;
@@ -1411,7 +1423,7 @@ export class YoutubePostNativeScrapper {
 
     const commentsButton = this.selectShortsCommentsButton();
     if (!commentsButton) {
-      this.warn("Failed to find shorts comments button");
+      logger.warn("Failed to find shorts comments button");
       return undefined;
     }
 
@@ -1430,7 +1442,7 @@ export class YoutubePostNativeScrapper {
     if (panelSelectionResult.status === "success") {
       return panelSelectionResult.element;
     }
-    this.warn(
+    logger.warn(
       "Shorts comments panel not visible after clicking comment button",
     );
     return undefined;

--- a/browser-extension/src/shared/screenshoting/scrollable/Scrollable.ts
+++ b/browser-extension/src/shared/screenshoting/scrollable/Scrollable.ts
@@ -1,8 +1,5 @@
 import { Image } from "image-js";
-import { createLogger } from "../../utils/createLogger";
 import { Size } from "../Size";
-
-export const logger = createLogger("[Screenshoting scrollable]");
 
 /**
  * Abstraction around scrollable element. mostly to accomodate some quirks on client size returned on youtube

--- a/browser-extension/src/shared/screenshoting/scrollable/scrollToAndWait.ts
+++ b/browser-extension/src/shared/screenshoting/scrollable/scrollToAndWait.ts
@@ -1,5 +1,7 @@
-import { Position, ScrollableScrollToOptions, logger } from "./Scrollable";
+import { createLogger } from "@/shared/utils/createLogger";
+import { Position, ScrollableScrollToOptions } from "./Scrollable";
 
+const logger = createLogger("[Screenshoting scrollToAndWait]");
 export async function scrollToAndWait(
   scrollable: Window | HTMLElement,
   scrollEndEventSource: Document | HTMLElement,


### PR DESCRIPTION
* refactor e2e scrapping tests to:
  * share generic expectations 
  * Share a common structure
  * Use serial tests to decompose assertions 

* Add support for e2e tests for youtube shorts scrapping by introducing a degraded scrapping mode that use  placeholder values  when data is missing due to youtube suspecting bot. This is only relevant when non authenticated scrapping on untrusted up (CI).