### PR TITLE
ci: skip  pr-comment for PR triggered by dependabot

### DIFF
--- a/.github/workflows/web-extension.yaml
+++ b/.github/workflows/web-extension.yaml
@@ -102,7 +102,7 @@ jobs:
           retention-days: 30
 
       - name: "[PR] Link artifacts in PR"
-        if: github.event_name == 'pull_request' && steps.upload-bth-extension-artifact.outcome == 'success'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && steps.upload-bth-extension-artifact.outcome == 'success'
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |


### PR DESCRIPTION
PR triggered by dependabot  only have read token(
See https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-on-actions#restrictions-when-dependabot-triggers-events)