### PR TITLE
[scraping] feat: include post URL in scraper error messages

### DIFF
--- a/browser-extension/src/shared/scraping-content-script/ScrapingContentScript.ts
+++ b/browser-extension/src/shared/scraping-content-script/ScrapingContentScript.ts
@@ -171,10 +171,11 @@ export class ScrapingContentScript {
         return;
       } else {
         logger.error("Unexpected error while scraping", e);
-        const errorMessage =
+        const errorDetails =
           e instanceof Error && e.stack
             ? `${e.message}\n${e.stack}`
             : String(e);
+        const errorMessage = `Post URL: ${window.location.href}\n${errorDetails}`;
         this.scrapAbortController = null;
         this.scrapingStatus = scrapingFailed(errorMessage);
         return;


### PR DESCRIPTION

Ajoute l'URL de la publication aux erreurs remontées par les scrapers pour simplifier le diagnostique
