### PR TITLE
[IG scraping] fix(ig): parse posts without likes or comments

### DIFF
--- a/browser-extension/src/entrypoints/instagram.content/og/__tests__/extractOgDescriptionInfo.test.ts
+++ b/browser-extension/src/entrypoints/instagram.content/og/__tests__/extractOgDescriptionInfo.test.ts
@@ -175,6 +175,22 @@ describe("parseOgDescriptionContent", () => {
     expect(result.textContent).toBe("Few comments");
   });
 
+  it("Should parse a post with no likes or comments", () => {
+    const ogDescription =
+      'isa_cest_moi_ on August 18, 2026: "#feminisme #sororité #pedagogie #egalitehommefemme #etreunefemme".';
+    const result: InstagramOgDescriptionInfo =
+      parseOgDescriptionContent(ogDescription);
+    expect(result.commentsCount).toBe(0);
+    expect(result.textContent).toBe(
+      "#feminisme #sororité #pedagogie #egalitehommefemme #etreunefemme",
+    );
+    expect(result.author).toEqual({
+      name: "isa_cest_moi_",
+      accountHref: "https://www.instagram.com/isa_cest_moi_",
+    });
+    expect(result.publishedAt.date).toBe("2026-08-18T00:00:00.000Z");
+  });
+
   it("Should throw error for invalid og:description format", () => {
     expect(() => parseOgDescriptionContent("invalid format")).toThrow();
     expect(() => parseOgDescriptionContent("missing quotes")).toThrow();

--- a/browser-extension/src/entrypoints/instagram.content/og/extractOgDescriptionInfo.ts
+++ b/browser-extension/src/entrypoints/instagram.content/og/extractOgDescriptionInfo.ts
@@ -35,15 +35,16 @@ export function extractOgDescriptionInfo(
 export function parseOgDescriptionContent(
   ogDescriptionContent: string,
 ): InstagramOgDescriptionInfo {
-  // og:description is of the form
+  // og:description is usually of the form
   // '<likesCount> likes, <commentsCount> comments - <accountName> le\u00A0 <dateFragment>: "<textContent>".'
   // Or
   // '<likesCount> likes, <commentsCount> comments - <accountName> on <dateFragment>: "<textContent>".'
   // Or
   // '<likesCount> likes, <commentsCount> comments - <accountName> on <dateFragment>'
+  // Instagram omits the engagement prefix when a post has no likes or comments.
 
   const regex =
-    /^[0-9, ]+K? likes, (?<commentsCount>[0-9, ]+) comments - (?<accountName>\S+)\s+(?:(le)|(on))\s+(?<dateFragment>[^:]*)(?:: "(?<textContent>.*)"\.)?\s*/gms;
+    /^(?:(?:[0-9, ]+K? likes, (?<commentsCount>[0-9, ]+) comments - ))?(?<accountName>\S+)\s+(?:(le)|(on))\s+(?<dateFragment>[^:]*)(?:: "(?<textContent>.*)"\.)?\s*/gms;
 
   const res = regex.exec(ogDescriptionContent);
   if (!res || !res.groups) {
@@ -54,9 +55,11 @@ export function parseOgDescriptionContent(
   const textContent = res.groups["textContent"] ?? "";
   const dateFragment = res.groups["dateFragment"]!;
   const accountName = res.groups["accountName"]!;
-  const commentsCount = Number.parseInt(
-    res.groups["commentsCount"]!.replaceAll(",", "").replaceAll(" ", ""),
-  );
+  const commentsCount = res.groups["commentsCount"]
+    ? Number.parseInt(
+        res.groups["commentsCount"].replaceAll(",", "").replaceAll(" ", ""),
+      )
+    : 0;
   const accountHref = `${INSTAGRAM_URL.origin}/${accountName}`;
   const publishedAt: PublicationDate = {
     type: "absolute",


### PR DESCRIPTION
Support Instagram `og:description` values without an engagement prefix.
 Default `commentsCount` to `0` for posts without likes or comments.
Fixes #409
