### PR TITLE
[YT scraping] fix: reload YouTube page when og:url is unavailable

### DIFF
--- a/browser-extension/src/entrypoints/youtube.content/YoutubeScraper.ts
+++ b/browser-extension/src/entrypoints/youtube.content/YoutubeScraper.ts
@@ -42,7 +42,12 @@ export class YoutubeScraper implements SocialNetworkScraper {
       if (this.allowDegradedScrapping) {
         logger.warn(message);
       } else {
-        throw new Error(message);
+        // YouTube can expose the new URL before it has refreshed the page metadata.
+        // Reloading gives the page a chance to populate og:url before scraping starts.
+        logger.info("og metadata unavailable reloading page");
+        return {
+          redirectUrl: document.URL,
+        };
       }
     } else if (isOutdatedOgMeta(ogUrl, document.URL)) {
       // Scraper uses og: meta information which are only loaded on page load not on navigation

--- a/browser-extension/src/entrypoints/youtube.content/__tests__/YoutubeScraper.test.ts
+++ b/browser-extension/src/entrypoints/youtube.content/__tests__/YoutubeScraper.test.ts
@@ -1,0 +1,17 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, test } from "vitest";
+import { YoutubeScraper } from "../YoutubeScraper";
+
+describe("YoutubeScraper", () => {
+  test("reloads the page when og:url is not available yet", async () => {
+    document.head.innerHTML = "";
+
+    const result = await new YoutubeScraper(false).scrapPagePost(
+      new AbortController().signal,
+      undefined!,
+    );
+
+    expect(result).toEqual({ redirectUrl: document.URL });
+  });
+});


### PR DESCRIPTION
Reload the current YouTube page when `og:url` is not available yet after client-side navigation.
Closes #407

